### PR TITLE
Cohesive shell script formatting

### DIFF
--- a/.config/lf/scope
+++ b/.config/lf/scope
@@ -2,7 +2,8 @@
 
 set -C -f -u
 #IFS=$'\n'
-IFS="$(printf '%b_' '\n')"; IFS="${IFS%_}"
+IFS="$(printf '%b_' '\n')"
+IFS="${IFS%_}"
 
 # ANSI color codes are supported.
 # STDIN is disabled, so interactive scripts won't work properly
@@ -17,42 +18,42 @@ IFS="$(printf '%b_' '\n')"; IFS="${IFS%_}"
 # 2    | plain text | Display the plain content of the file
 
 # Script arguments
-FILE_PATH="${1}"         # Full path of the highlighted file
+FILE_PATH="${1}" # Full path of the highlighted file
 HEIGHT="${2}"
 
 #FILE_EXTENSION="${FILE_PATH##*.}"
 #FILE_EXTENSION_LOWER=$(echo ${FILE_EXTENSION} | tr '[:upper:]' '[:lower:]')
 
 # Settings
-HIGHLIGHT_SIZE_MAX=262143  # 256KiB
+HIGHLIGHT_SIZE_MAX=262143 # 256KiB
 HIGHLIGHT_TABWIDTH=8
 HIGHLIGHT_STYLE='pablo'
-
 
 handle_mime() {
     local mimetype="${1}"
     case "${mimetype}" in
-	text/html) w3m -dump "${FILE_PATH}" ;;
-	text/troff) man ./ "${FILE_PATH}" | col -b ;;
-	text/* | */xml)
-            if [ "$( stat --printf='%s' -- "${FILE_PATH}" )" -gt "${HIGHLIGHT_SIZE_MAX}" ]; then
+        text/html) w3m -dump "${FILE_PATH}" ;;
+        text/troff) man ./ "${FILE_PATH}" | col -b ;;
+        text/* | */xml)
+            if [ "$(stat --printf='%s' -- "${FILE_PATH}")" -gt "${HIGHLIGHT_SIZE_MAX}" ]; then
                 exit 2
             fi
-            if [ "$( tput colors )" -ge 256 ]; then
+            if [ "$(tput colors)" -ge 256 ]; then
                 local highlight_format='xterm256'
             else
                 local highlight_format='ansi'
             fi
             highlight --replace-tabs="${HIGHLIGHT_TABWIDTH}" --out-format="${highlight_format}" \
-                --style="${HIGHLIGHT_STYLE}" --force -- "${FILE_PATH}" ;;
-	application/zip) atool --list -- "${FILE_PATH}" ;;
-        image/*) chafa --fill=block --symbols=block -c 256 -s 80x"${HEIGHT}" "${FILE_PATH}" || exit 1;;
-        video/* | audio/*|application/octet-stream) mediainfo "${FILE_PATH}" || exit 1;;
+                --style="${HIGHLIGHT_STYLE}" --force -- "${FILE_PATH}"
+            ;;
+        application/zip) atool --list -- "${FILE_PATH}" ;;
+        image/*) chafa --fill=block --symbols=block -c 256 -s 80x"${HEIGHT}" "${FILE_PATH}" || exit 1 ;;
+        video/* | audio/* | application/octet-stream) mediainfo "${FILE_PATH}" || exit 1 ;;
         */pdf) pdftotext -l 10 -nopgbrk -q -- "${FILE_PATH}" - ;;
         *opendocument*) odt2txt "${FILE_PATH}" ;;
     esac
 }
 
-MIMETYPE="$( file --dereference --brief --mime-type -- "${FILE_PATH}" )"
+MIMETYPE="$(file --dereference --brief --mime-type -- "${FILE_PATH}")"
 handle_mime "${MIMETYPE}"
 exit 1

--- a/.config/shell/aliasrc
+++ b/.config/shell/aliasrc
@@ -7,44 +7,44 @@
 [ -f "$XINITRC" ] && alias startx="startx $XINITRC"
 
 # sudo not required for some system commands
-for x in mount umount sv pacman updatedb su ; do
-	alias $x="sudo $x"
+for x in mount umount sv pacman updatedb su; do
+    alias $x="sudo $x"
 done
 
 # Verbosity and settings that you pretty much just always are going to want.
 alias \
-	cp="cp -iv" \
-	mv="mv -iv" \
-	rm="rm -vI" \
-	bc="bc -ql" \
-	mkd="mkdir -pv" \
-	yt="youtube-dl --add-metadata -i" \
-	yta="yt -x -f bestaudio/best" \
-	ffmpeg="ffmpeg -hide_banner"
+    cp="cp -iv" \
+    mv="mv -iv" \
+    rm="rm -vI" \
+    bc="bc -ql" \
+    mkd="mkdir -pv" \
+    yt="youtube-dl --add-metadata -i" \
+    yta="yt -x -f bestaudio/best" \
+    ffmpeg="ffmpeg -hide_banner"
 
 # Colorize commands when possible.
 alias \
-	ls="ls -hN --color=auto --group-directories-first" \
-	grep="grep --color=auto" \
-	diff="diff --color=auto" \
-	ccat="highlight --out-format=ansi"
+    ls="ls -hN --color=auto --group-directories-first" \
+    grep="grep --color=auto" \
+    diff="diff --color=auto" \
+    ccat="highlight --out-format=ansi"
 
 # These common commands are just too long! Abbreviate them.
 alias \
-	ka="killall" \
-	g="git" \
-	trem="transmission-remote" \
-	YT="youtube-viewer" \
-	sdn="sudo shutdown -h now" \
-	e="$EDITOR" \
-	v="$EDITOR" \
-	p="sudo pacman" \
-	xi="sudo xbps-install" \
-	xr="sudo xbps-remove -R" \
-	xq="xbps-query" \
-	z="zathura"
+    ka="killall" \
+    g="git" \
+    trem="transmission-remote" \
+    YT="youtube-viewer" \
+    sdn="sudo shutdown -h now" \
+    e="$EDITOR" \
+    v="$EDITOR" \
+    p="sudo pacman" \
+    xi="sudo xbps-install" \
+    xr="sudo xbps-remove -R" \
+    xq="xbps-query" \
+    z="zathura"
 
 alias \
-	magit="nvim -c MagitOnly" \
-	ref="shortcuts >/dev/null; source ${XDG_CONFIG_HOME:-$HOME/.config}/shortcutrc ; source ${XDG_CONFIG_HOME:-$HOME/.config}/zshnameddirrc" \
-	weath="less -S ${XDG_DATA_HOME:-$HOME/.local/share}/weatherreport" \
+    magit="nvim -c MagitOnly" \
+    ref="shortcuts >/dev/null; source ${XDG_CONFIG_HOME:-$HOME/.config}/shortcutrc ; source ${XDG_CONFIG_HOME:-$HOME/.config}/zshnameddirrc" \
+    weath="less -S ${XDG_DATA_HOME:-$HOME/.local/share}/weatherreport"

--- a/.config/sxiv/exec/key-handler
+++ b/.config/sxiv/exec/key-handler
@@ -1,33 +1,38 @@
 #!/bin/sh
-while read file
-do
-        case "$1" in
+while read file; do
+    case "$1" in
         "w") setbg "$file" & ;;
         "c")
-		[ -z "$destdir" ] && destdir="$(sed "s/\s.*#.*$//;/^\s*$/d" ${XDG_CONFIG_HOME:-$HOME/.config}/shell/bm-dirs | awk '{print $2}' | dmenu -l 20 -i -p "Copy file(s) to where?" | sed "s|~|$HOME|g")"
-		[ ! -d "$destdir" ] && notify-send "$destdir is not a directory, cancelled." && exit
-		cp "$file" "$destdir" && notify-send -i "$(readlink -f "$file")" "$file copied to $destdir." &
-		;;
+            [ -z "$destdir" ] && destdir="$(sed "s/\s.*#.*$//;/^\s*$/d" ${XDG_CONFIG_HOME:-$HOME/.config}/shell/bm-dirs | awk '{print $2}' | dmenu -l 20 -i -p "Copy file(s) to where?" | sed "s|~|$HOME|g")"
+            [ ! -d "$destdir" ] && notify-send "$destdir is not a directory, cancelled." && exit
+            cp "$file" "$destdir" && notify-send -i "$(readlink -f "$file")" "$file copied to $destdir." &
+            ;;
         "m")
-		[ -z "$destdir" ] && destdir="$(sed "s/\s.*#.*$//;/^\s*$/d" ${XDG_CONFIG_HOME:-$HOME/.config}/shell/bm-dirs | awk '{print $2}' | dmenu -l 20 -i -p "Move file(s) to where?" | sed "s|~|$HOME|g")"
-		[ ! -d "$destdir" ] && notify-send "$destdir is not a directory, cancelled." && exit
-		mv "$file" "$destdir" && notify-send -i "$(readlink -f "$file")" "$file moved to $destdir." &
-		;;
-	"r")
-		convert -rotate 90 "$file" "$file" ;;
-	"R")
-		convert -rotate -90 "$file" "$file" ;;
-	"f")
-		convert -flop "$file" "$file" ;;
-	"y")
-		echo -n "$file" | tr -d '\n' | xclip -selection clipboard &&
-		notify-send "$file copied to clipboard" & ;;
-	"Y")
-		readlink -f "$file" | tr -d '\n' | xclip -selection clipboard &&
-			notify-send "$(readlink -f "$file") copied to clipboard" & ;;
-	"d")
-		[ "$(printf "No\\nYes" | dmenu -i -p "Really delete $file?")" = "Yes" ] && rm "$file" && notify-send "$file deleted." ;;
-	"g")	ifinstalled gimp && setsid -f gimp "$file" ;;
-	"i")	notify-send "File information" "$(mediainfo "$file")" ;;
-        esac
+            [ -z "$destdir" ] && destdir="$(sed "s/\s.*#.*$//;/^\s*$/d" ${XDG_CONFIG_HOME:-$HOME/.config}/shell/bm-dirs | awk '{print $2}' | dmenu -l 20 -i -p "Move file(s) to where?" | sed "s|~|$HOME|g")"
+            [ ! -d "$destdir" ] && notify-send "$destdir is not a directory, cancelled." && exit
+            mv "$file" "$destdir" && notify-send -i "$(readlink -f "$file")" "$file moved to $destdir." &
+            ;;
+        "r")
+            convert -rotate 90 "$file" "$file"
+            ;;
+        "R")
+            convert -rotate -90 "$file" "$file"
+            ;;
+        "f")
+            convert -flop "$file" "$file"
+            ;;
+        "y")
+            echo -n "$file" | tr -d '\n' | xclip -selection clipboard \
+                && notify-send "$file copied to clipboard" &
+            ;;
+        "Y")
+            readlink -f "$file" | tr -d '\n' | xclip -selection clipboard \
+                && notify-send "$(readlink -f "$file") copied to clipboard" &
+            ;;
+        "d")
+            [ "$(printf 'No\nYes' | dmenu -i -p "Really delete $file?")" = "Yes" ] && rm "$file" && notify-send "$file deleted."
+            ;;
+        "g") ifinstalled gimp && setsid -f gimp "$file" ;;
+        "i") notify-send "File information" "$(mediainfo "$file")" ;;
+    esac
 done

--- a/.config/wal/postrun
+++ b/.config/wal/postrun
@@ -2,26 +2,26 @@
 
 source "${HOME}/.cache/wal/colors.sh"
 
-mkdir -p  "${HOME}/.config/dunst"
-mkdir -p  "${HOME}/.config/zathura"
-ln -sf    "${HOME}/.cache/wal/dunstrc"    "${HOME}/.config/dunst/dunstrc"
-ln -sf    "${HOME}/.cache/wal/zathurarc"    "${HOME}/.config/zathura/zathurarc"
+mkdir -p "${HOME}/.config/dunst"
+mkdir -p "${HOME}/.config/zathura"
+ln -sf "${HOME}/.cache/wal/dunstrc" "${HOME}/.config/dunst/dunstrc"
+ln -sf "${HOME}/.cache/wal/zathurarc" "${HOME}/.config/zathura/zathurarc"
 
 fix_sequences() {
-        e=$'\e'
-        sequences=$(cat)
-        foreground_color="$(echo -e "${sequences}\c" | grep --color=never -Eo "${e}]10[^${e}\\\\]*?${e}\\\\" | grep --color=never -Eo "#[0-9A-Fa-f]{6}")"
-        background_color="$(echo -e "${sequences}\c" | grep --color=never -Eo "${e}]11[^${e}\\\\]*?${e}\\\\" | grep --color=never -Eo "#[0-9A-Fa-f]{6}")"
-        cursor_color="$(echo -e "${sequences}\c" | grep --color=never -Eo "${e}]12[^${e}\\\\]*?${e}\\\\" | grep --color=never -Eo "#[0-9A-Fa-f]{6}")"
+    e=$'\e'
+    sequences=$(cat)
+    foreground_color="$(echo -e "${sequences}\c" | grep --color=never -Eo "${e}]10[^${e}\\\\]*?${e}\\\\" | grep --color=never -Eo "#[0-9A-Fa-f]{6}")"
+    background_color="$(echo -e "${sequences}\c" | grep --color=never -Eo "${e}]11[^${e}\\\\]*?${e}\\\\" | grep --color=never -Eo "#[0-9A-Fa-f]{6}")"
+    cursor_color="$(echo -e "${sequences}\c" | grep --color=never -Eo "${e}]12[^${e}\\\\]*?${e}\\\\" | grep --color=never -Eo "#[0-9A-Fa-f]{6}")"
 
-for term in /dev/pts/{0..9}*
-do
-echo -e "\e]4;256;${cursor_color}\a\c" > "${term}" 2>/dev/null
-echo -e "\e]4;258;${background_color}\a\c" > "${term}" 2>/dev/null
-echo -e "\e]4;259;${foreground_color}\a\c" > "${term}" 2>/dev/null
-done
+    for term in /dev/pts/{0..9}*; do
+        echo -e "\e]4;256;${cursor_color}\a\c" > "${term}" 2> /dev/null
+        echo -e "\e]4;258;${background_color}\a\c" > "${term}" 2> /dev/null
+        echo -e "\e]4;259;${foreground_color}\a\c" > "${term}" 2> /dev/null
+    done
 }
 
-fix_sequences <"${HOME}/.cache/wal/sequences"
+fix_sequences < "${HOME}/.cache/wal/sequences"
 
-pkill dunst; dunst &
+pkill dunst
+dunst &

--- a/.config/x11/xinitrc
+++ b/.config/x11/xinitrc
@@ -9,9 +9,9 @@
 # I source them here with the line below.
 
 if [ -f "${XDG_CONFIG_HOME:-$HOME/.config}/x11/xprofile" ]; then
-	. "${XDG_CONFIG_HOME:-$HOME/.config}/x11/xprofile"
+    . "${XDG_CONFIG_HOME:-$HOME/.config}/x11/xprofile"
 else
-	. "$HOME/.xprofile"
+    . "$HOME/.xprofile"
 fi
 
 ssh-agent dwm

--- a/.config/x11/xprofile
+++ b/.config/x11/xprofile
@@ -3,18 +3,18 @@
 # This file runs when a DM logs you into a graphical session.
 # If you use startx/xinit like a Chad, this file will also be sourced.
 
-setbg &			# set the background with the `setbg` script
+setbg & # set the background with the `setbg` script
 #xrdb ${XDG_CONFIG_HOME:-$HOME/.config}/x11/xresources &	# Uncomment to use Xresources colors/settings on startup
-mpd &			# music player daemon-you might prefer it as a service though
-remaps &		# run the remaps script, switching caps/esc and more; check it for more info
-xcompmgr &		# xcompmgr for transparency
-dunst &			# dunst for notifications
-xset r rate 300 50 &	# Speed xrate up
-unclutter &		# Remove mouse when idle
+mpd &                # music player daemon-you might prefer it as a service though
+remaps &             # run the remaps script, switching caps/esc and more; check it for more info
+xcompmgr &           # xcompmgr for transparency
+dunst &              # dunst for notifications
+xset r rate 300 50 & # Speed xrate up
+unclutter &          # Remove mouse when idle
 
 # This line autostarts an instance of Pulseaudio that does not exit on idle.
 # This is "necessary" on Artix due to a current bug between PA and
 # Chromium-based browsers where they fail to start PA and use dummy output.
-pidof -s runit &&
-	! pidof -s pulseaudio >/dev/null 2>&1 &&
-	setsid -f pulseaudio --start --exit-idle-time=-1 >/dev/null 2>&1
+pidof -s runit \
+    && ! pidof -s pulseaudio > /dev/null 2>&1 \
+    && setsid -f pulseaudio --start --exit-idle-time=-1 > /dev/null 2>&1

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -1,0 +1,38 @@
+name: shfmt-linter
+
+on:
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  shellcheck:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+         ref: ${{ github.head_ref }}
+    
+    - name: update system
+      run: |
+            sudo apt-get upgrade --install-suggests --yes
+        
+    - name: install dependencies
+      run: |
+            sudo apt-get install git \
+                                 make
+
+    - name: apply shfmt fixes
+      run: |
+            docker run --volume "$PWD":/mnt \
+                       --rm \
+                       mvdan/shfmt -bn -ci -d -i 4 -p -s -sr -w /mnt
+                       
+    - uses: stefanzweifel/git-auto-commit-action@v4
+      with:
+        commit_message: (maint) apply shfmt formatting
+        commit_options: '--cleanup=default --no-verify --signoff'
+        push_options: '--force'
+        skip_dirty_check: false    

--- a/.local/bin/booksplit
+++ b/.local/bin/booksplit
@@ -2,13 +2,16 @@
 
 # Requires ffmpeg (audio splitting) and my `tag` wrapper script.
 
-[ ! -f "$2" ] && printf "The first file should be the audio, the second should be the timecodes.\\n" && exit
+[ ! -f "$2" ] && printf 'The first file should be the audio, the second should be the timecodes.\n' && exit
 
-echo "Enter the album/book title:"; read -r booktitle
+echo "Enter the album/book title:"
+read -r booktitle
 
-echo "Enter the artist/author:"; read -r author
+echo "Enter the artist/author:"
+read -r author
 
-echo "Enter the publication year:"; read -r year
+echo "Enter the publication year:"
+read -r year
 
 inputaudio="$1"
 
@@ -24,23 +27,22 @@ ext="opus"
 # Get the total number of tracks from the number of lines.
 total="$(wc -l < "$2")"
 
-while read -r x;
-do
-	end="$(echo "$x" | cut -d' ' -f1)"
+while read -r x; do
+    end="$(echo "$x" | cut -d' ' -f1)"
 
-	[ -n "$start" ] &&
-	echo "From $start to $end; $track $title"
-	file="$escbook/$(printf "%.2d" "$track")-$esctitle.$ext"
-	[ -n "$start" ] && echo "Splitting \"$title\"..." &&
-   	ffmpeg -nostdin -y -loglevel -8 -i "$inputaudio" -ss "$start" -to "$end" -vn -c copy "$file" &&
-	echo "Tagging \"$title\"..." && tag -a "$author" -A "$booktitle" -t "$title" -n "$track" -N "$total" -d "$year" "$file"
-	title="$(echo "$x" | cut -d' ' -f 2-)"
-	esctitle="$(echo "$title" | iconv -cf UTF-8 -t ASCII//TRANSLIT | tr -d '[:punct:]' | tr '[:upper:]' '[:lower:]' | tr ' ' '-' | sed "s/-\+/-/g;s/\(^-\|-\$\)//g")"
-	track="$((track+1))"
-	start="$end"
+    [ -n "$start" ] \
+        && echo "From $start to $end; $track $title"
+    file="$escbook/$(printf "%.2d" "$track")-$esctitle.$ext"
+    [ -n "$start" ] && echo "Splitting \"$title\"..." \
+        && ffmpeg -nostdin -y -loglevel -8 -i "$inputaudio" -ss "$start" -to "$end" -vn -c copy "$file" \
+        && echo "Tagging \"$title\"..." && tag -a "$author" -A "$booktitle" -t "$title" -n "$track" -N "$total" -d "$year" "$file"
+    title="$(echo "$x" | cut -d' ' -f 2-)"
+    esctitle="$(echo "$title" | iconv -cf UTF-8 -t ASCII//TRANSLIT | tr -d '[:punct:]' | tr '[:upper:]' '[:lower:]' | tr ' ' '-' | sed "s/-\+/-/g;s/\(^-\|-\$\)//g")"
+    track="$((track + 1))"
+    start="$end"
 done < "$2"
 # The last track must be done outside the loop.
 echo "From $start to the end: $title"
 file="$escbook/$(printf "%.2d" "$track")-$esctitle.$ext"
-echo "Splitting \"$title\"..." && ffmpeg -nostdin -y -loglevel -8 -i "$inputaudio" -ss "$start" -vn -c copy "$file" &&
-		echo "Tagging \"$title\"..." && tag -a "$author" -A "$booktitle" -t "$title" -n "$track" -N "$total" -d "$year" "$file"
+echo "Splitting \"$title\"..." && ffmpeg -nostdin -y -loglevel -8 -i "$inputaudio" -ss "$start" -vn -c copy "$file" \
+    && echo "Tagging \"$title\"..." && tag -a "$author" -A "$booktitle" -t "$title" -n "$track" -N "$total" -d "$year" "$file"

--- a/.local/bin/compiler
+++ b/.local/bin/compiler
@@ -16,42 +16,42 @@ ext="${file##*.}"
 
 cd "$dir" || exit 1
 
-textype() { \
-	command="pdflatex"
-	( head -n5 "$file" | grep -qi 'xelatex' ) && command="xelatex"
-	$command --output-directory="$dir" "$base" &&
-	grep -qi addbibresource "$file" &&
-	biber --input-directory "$dir" "$base" &&
-	$command --output-directory="$dir" "$base" &&
-	$command --output-directory="$dir" "$base"
+textype() {
+    command="pdflatex"
+    (head -n5 "$file" | grep -qi 'xelatex') && command="xelatex"
+    $command --output-directory="$dir" "$base" \
+        && grep -qi addbibresource "$file" \
+        && biber --input-directory "$dir" "$base" \
+        && $command --output-directory="$dir" "$base" \
+        && $command --output-directory="$dir" "$base"
 }
 
 case "$ext" in
-	# Try to keep these cases in alphabetical order.
-	[0-9]) preconv "$file" | refer -PS -e | groff -mandoc -T pdf > "$base".pdf ;;
-	c) cc "$file" -o "$base" && "$base" ;;
-	cpp) g++ "$file" -o "$base" && "$base" ;;
-	cs) mcs "$file" && mono "$base".exe ;;
-	go) go run "$file" ;;
-	h) sudo make install ;;
-	java) javac -d classes "$file" && java -cp classes "${1%.*}" ;;
-	m) octave "$file" ;;
-	md)	if  [ -x "$(command -v lowdown)" ]; then
-			lowdown -d nointem -e super "$file" -Tms | groff -mpdfmark -ms -kept > "$base".pdf
-		elif [ -x "$(command -v groffdown)" ]; then
-			groffdown -i "$file" | groff > "$base.pdf"
-		else
-			pandoc -t ms --highlight-style=kate -s -o "$base".pdf "$file"
-		fi ; ;;
-	mom) preconv "$file" | refer -PS -e | groff -mom -kept -T pdf > "$base".pdf ;;
-	ms) preconv "$file" | refer -PS -e | groff -me -ms -kept -T pdf > "$base".pdf ;;
-	org) emacs "$file" --batch -u "$USER" -f org-latex-export-to-pdf ;;
-	py) python "$file" ;;
-	[rR]md) Rscript -e "rmarkdown::render('$file', quiet=TRUE)" ;;
-	rs) cargo build ;;
-	sass) sassc -a "$file" "$base.css" ;;
-	scad) openscad -o "$base".stl "$file" ;;
-	sent) setsid -f sent "$file" 2>/dev/null ;;
-	tex) textype "$file" ;;
-	*) head -n1 "$file" | grep "^#!/" | sed "s/^#!//" | xargs -r -I % "$file" ;;
+    # Try to keep these cases in alphabetical order.
+    [0-9]) preconv "$file" | refer -PS -e | groff -mandoc -T pdf > "$base".pdf ;;
+    c) cc "$file" -o "$base" && "$base" ;;
+    cpp) g++ "$file" -o "$base" && "$base" ;;
+    cs) mcs "$file" && mono "$base".exe ;;
+    go) go run "$file" ;;
+    h) sudo make install ;;
+    java) javac -d classes "$file" && java -cp classes "${1%.*}" ;;
+    m) octave "$file" ;;
+    md) if [ -x "$(command -v lowdown)" ]; then
+        lowdown -d nointem -e super "$file" -Tms | groff -mpdfmark -ms -kept > "$base".pdf
+    elif [ -x "$(command -v groffdown)" ]; then
+        groffdown -i "$file" | groff > "$base.pdf"
+    else
+        pandoc -t ms --highlight-style=kate -s -o "$base".pdf "$file"
+    fi ;;
+    mom) preconv "$file" | refer -PS -e | groff -mom -kept -T pdf > "$base".pdf ;;
+    ms) preconv "$file" | refer -PS -e | groff -me -ms -kept -T pdf > "$base".pdf ;;
+    org) emacs "$file" --batch -u "$USER" -f org-latex-export-to-pdf ;;
+    py) python "$file" ;;
+    [rR]md) Rscript -e "rmarkdown::render('$file', quiet=TRUE)" ;;
+    rs) cargo build ;;
+    sass) sassc -a "$file" "$base.css" ;;
+    scad) openscad -o "$base".stl "$file" ;;
+    sent) setsid -f sent "$file" 2> /dev/null ;;
+    tex) textype "$file" ;;
+    *) head -n1 "$file" | grep "^#!/" | sed "s/^#!//" | xargs -r -I % "$file" ;;
 esac

--- a/.local/bin/cron/checkup
+++ b/.local/bin/cron/checkup
@@ -11,9 +11,8 @@ sudo pacman -Syyuw --noconfirm || notify-send "Error downloading updates.
 Check your internet connection, if pacman is already running, or run update manually to see errors."
 pkill -RTMIN+8 "${STATUSBAR:-dwmblocks}"
 
-if pacman -Qu | grep -v "\[ignored\]"
-then
-	notify-send "🎁 Repository Sync" "Updates available. Click statusbar icon (📦) for update."
+if pacman -Qu | grep -v "\[ignored\]"; then
+    notify-send "🎁 Repository Sync" "Updates available. Click statusbar icon (📦) for update."
 else
-	notify-send "📦 Repository Sync"  "Sync complete. No new packages for update."
+    notify-send "📦 Repository Sync" "Sync complete. No new packages for update."
 fi

--- a/.local/bin/cron/crontog
+++ b/.local/bin/cron/crontog
@@ -3,4 +3,4 @@
 # Toggles all cronjobs off/on.
 # Stores disabled crontabs in ~/.consaved until restored.
 
-([ -f "${XDG_CONFIG_HOME:-$HOME/.config}"/cronsaved ] && crontab - < "${XDG_CONFIG_HOME:-$HOME/.config}"/cronsaved  && rm "${XDG_CONFIG_HOME:-$HOME/.config}"/cronsaved && notify-send "🕓 Cronjobs re-enabled.") || ( crontab -l > "${XDG_CONFIG_HOME:-$HOME/.config}"/cronsaved && crontab -r && notify-send "🕓 Cronjobs saved and disabled.")
+([ -f "${XDG_CONFIG_HOME:-$HOME/.config}"/cronsaved ] && crontab - < "${XDG_CONFIG_HOME:-$HOME/.config}"/cronsaved && rm "${XDG_CONFIG_HOME:-$HOME/.config}"/cronsaved && notify-send "🕓 Cronjobs re-enabled.") || (crontab -l > "${XDG_CONFIG_HOME:-$HOME/.config}"/cronsaved && crontab -r && notify-send "🕓 Cronjobs saved and disabled.")

--- a/.local/bin/displayselect
+++ b/.local/bin/displayselect
@@ -6,17 +6,17 @@
 
 twoscreen() { # If multi-monitor is selected and there are two screens.
 
-    mirror=$(printf "no\\nyes" | dmenu -i -p "Mirror displays?")
+    mirror=$(printf 'no\nyes' | dmenu -i -p "Mirror displays?")
     # Mirror displays using native resolution of external display and a scaled
     # version for the internal display
     if [ "$mirror" = "yes" ]; then
         external=$(echo "$screens" | dmenu -i -p "Optimize resolution for:")
         internal=$(echo "$screens" | grep -v "$external")
 
-        res_external=$(xrandr --query | sed -n "/^$external/,/\+/p" | \
-            tail -n 1 | awk '{print $1}')
-        res_internal=$(xrandr --query | sed -n "/^$internal/,/\+/p" | \
-            tail -n 1 | awk '{print $1}')
+        res_external=$(xrandr --query | sed -n "/^$external/,/\+/p" \
+            | tail -n 1 | awk '{print $1}')
+        res_internal=$(xrandr --query | sed -n "/^$internal/,/\+/p" \
+            | tail -n 1 | awk '{print $1}')
 
         res_ext_x=$(echo "$res_external" | sed 's/x.*//')
         res_ext_y=$(echo "$res_external" | sed 's/.*x//')
@@ -33,34 +33,38 @@ twoscreen() { # If multi-monitor is selected and there are two screens.
 
         primary=$(echo "$screens" | dmenu -i -p "Select primary display:")
         secondary=$(echo "$screens" | grep -v "$primary")
-        direction=$(printf "left\\nright" | dmenu -i -p "What side of $primary should $secondary be on?")
+        direction=$(printf 'left\nright' | dmenu -i -p "What side of $primary should $secondary be on?")
         xrandr --output "$primary" --auto --scale 1.0x1.0 --output "$secondary" --"$direction"-of "$primary" --auto --scale 1.0x1.0
     fi
-    }
+}
 
 morescreen() { # If multi-monitor is selected and there are more than two screens.
-	primary=$(echo "$screens" | dmenu -i -p "Select primary display:")
-	secondary=$(echo "$screens" | grep -v "$primary" | dmenu -i -p "Select secondary display:")
-	direction=$(printf "left\\nright" | dmenu -i -p "What side of $primary should $secondary be on?")
-	tertiary=$(echo "$screens" | grep -v "$primary" | grep -v "$secondary" | dmenu -i -p "Select third display:")
-	xrandr --output "$primary" --auto --output "$secondary" --"$direction"-of "$primary" --auto --output "$tertiary" --"$(printf "left\\nright" | grep -v "$direction")"-of "$primary" --auto
-	}
+    primary=$(echo "$screens" | dmenu -i -p "Select primary display:")
+    secondary=$(echo "$screens" | grep -v "$primary" | dmenu -i -p "Select secondary display:")
+    direction=$(printf 'left\nright' | dmenu -i -p "What side of $primary should $secondary be on?")
+    tertiary=$(echo "$screens" | grep -v "$primary" | grep -v "$secondary" | dmenu -i -p "Select third display:")
+    xrandr --output "$primary" --auto --output "$secondary" --"$direction"-of "$primary" --auto --output "$tertiary" --"$(printf 'left\nright' | grep -v "$direction")"-of "$primary" --auto
+}
 
 multimon() { # Multi-monitor handler.
-	case "$(echo "$screens" | wc -l)" in
-		2) twoscreen ;;
-		*) morescreen ;;
-	esac ;}
+    case "$(echo "$screens" | wc -l)" in
+        2) twoscreen ;;
+        *) morescreen ;;
+    esac
+}
 
 onescreen() { # If only one output available or chosen.
-	xrandr --output "$1" --auto --scale 1.0x1.0 $(echo "$allposs" | grep -v "\b$1" | awk '{print "--output", $1, "--off"}' | paste -sd ' ' -)
-	}
+    xrandr --output "$1" --auto --scale 1.0x1.0 $(echo "$allposs" | grep -v "\b$1" | awk '{print "--output", $1, "--off"}' | paste -sd ' ' -)
+}
 
 postrun() { # Stuff to run to clean up.
-	setbg		# Fix background if screen size/arangement has changed.
-	remaps		# Re-remap keys if keyboard added (for laptop bases)
-	{ killall dunst ; setsid -f dunst ;} >/dev/null 2>&1 # Restart dunst to ensure proper location on screen
-	}
+    setbg   # Fix background if screen size/arangement has changed.
+    remaps  # Re-remap keys if keyboard added (for laptop bases)
+    {
+        killall dunst
+        setsid -f dunst
+    } > /dev/null 2>&1 # Restart dunst to ensure proper location on screen
+}
 
 # Get all possible displays
 allposs=$(xrandr -q | grep "connected")
@@ -69,15 +73,23 @@ allposs=$(xrandr -q | grep "connected")
 screens=$(echo "$allposs" | awk '/ connected/ {print $1}')
 
 # If there's only one screen
-[ "$(echo "$screens" | wc -l)" -lt 2 ] &&
-	{ onescreen "$screens"; postrun; notify-send "💻 Only one screen detected." "Using it in its optimal settings...";  exit ;}
+[ "$(echo "$screens" | wc -l)" -lt 2 ] \
+    && {
+        onescreen "$screens"
+        postrun
+        notify-send "💻 Only one screen detected." "Using it in its optimal settings..."
+        exit
+    }
 
 # Get user choice including multi-monitor and manual selection:
-chosen=$(printf "%s\\nmulti-monitor\\nmanual selection" "$screens" | dmenu -i -p "Select display arangement:") &&
-case "$chosen" in
-	"manual selection") arandr ; exit ;;
-	"multi-monitor") multimon ;;
-	*) onescreen "$chosen" ;;
-esac
+chosen=$(printf '%s\nmulti-monitor\nmanual selection' "$screens" | dmenu -i -p "Select display arangement:") \
+    && case "$chosen" in
+        "manual selection")
+            arandr
+            exit
+            ;;
+        "multi-monitor") multimon ;;
+        *) onescreen "$chosen" ;;
+    esac
 
 postrun

--- a/.local/bin/dmenuhandler
+++ b/.local/bin/dmenuhandler
@@ -4,18 +4,21 @@
 # some choice programs to use to open it.
 feed="${1:-$(printf "%s" | dmenu -p 'Paste URL or file path')}"
 
-case "$(printf "Copy URL\\nsxiv\\nsetbg\\nPDF\\nbrowser\\nlynx\\nvim\\nmpv\\nmpv loop\\nmpv float\\nqueue download\\nqueue yt-dl\\nqueue yt-dl audio" | dmenu -i -p "Open it with?")" in
-	"copy url") echo "$feed" | xclip -selection clipboard ;;
-	mpv) setsid -f mpv -quiet "$feed" >/dev/null 2>&1 ;;
-	"mpv loop") setsid -f mpv -quiet --loop "$feed" >/dev/null 2>&1 ;;
-	"mpv float") setsid -f "$TERMINAL" -e mpv --geometry=+0-0 --autofit=30%  --title="mpvfloat" "$feed" >/dev/null 2>&1 ;;
-	"queue yt-dl") qndl "$feed" >/dev/null 2>&1 ;;
-	"queue yt-dl audio") qndl "$feed" 'youtube-dl --add-metadata -icx -f bestaudio/best' >/dev/null 2>&1 ;;
-	"queue download") qndl "$feed" 'curl -LO' >/dev/null 2>&1 ;;
-	PDF) curl -sL "$feed" > "/tmp/$(echo "$feed" | sed "s/.*\///;s/%20/ /g")" && zathura "/tmp/$(echo "$feed" | sed "s/.*\///;s/%20/ /g")"  >/dev/null 2>&1 ;;
-	sxiv) curl -sL "$feed" > "/tmp/$(echo "$feed" | sed "s/.*\///;s/%20/ /g")" && sxiv -a "/tmp/$(echo "$feed" | sed "s/.*\///;s/%20/ /g")"  >/dev/null 2>&1 ;;
-	vim) curl -sL "$feed" > "/tmp/$(echo "$feed" | sed "s/.*\///;s/%20/ /g")" && setsid -f "$TERMINAL" -e "$EDITOR" "/tmp/$(echo "$feed" | sed "s/.*\///;s/%20/ /g")"  >/dev/null 2>&1 ;;
-	setbg) curl -L "$feed" > $XDG_CACHE_HOME/pic ; xwallpaper --zoom $XDG_CACHE_HOME/pic >/dev/null 2>&1 ;;
-	browser) setsid -f "$BROWSER" "$feed" >/dev/null 2>&1 ;;
-	lynx) lynx "$feed" >/dev/null 2>&1 ;;
+case "$(printf 'Copy URL\nsxiv\nsetbg\nPDF\nbrowser\nlynx\nvim\nmpv\nmpv loop\nmpv float\nqueue download\nqueue yt-dl\nqueue yt-dl audio' | dmenu -i -p "Open it with?")" in
+    "copy url") echo "$feed" | xclip -selection clipboard ;;
+    mpv) setsid -f mpv -quiet "$feed" > /dev/null 2>&1 ;;
+    "mpv loop") setsid -f mpv -quiet --loop "$feed" > /dev/null 2>&1 ;;
+    "mpv float") setsid -f "$TERMINAL" -e mpv --geometry=+0-0 --autofit=30% --title="mpvfloat" "$feed" > /dev/null 2>&1 ;;
+    "queue yt-dl") qndl "$feed" > /dev/null 2>&1 ;;
+    "queue yt-dl audio") qndl "$feed" 'youtube-dl --add-metadata -icx -f bestaudio/best' > /dev/null 2>&1 ;;
+    "queue download") qndl "$feed" 'curl -LO' > /dev/null 2>&1 ;;
+    PDF) curl -sL "$feed" > "/tmp/$(echo "$feed" | sed "s/.*\///;s/%20/ /g")" && zathura "/tmp/$(echo "$feed" | sed "s/.*\///;s/%20/ /g")" > /dev/null 2>&1 ;;
+    sxiv) curl -sL "$feed" > "/tmp/$(echo "$feed" | sed "s/.*\///;s/%20/ /g")" && sxiv -a "/tmp/$(echo "$feed" | sed "s/.*\///;s/%20/ /g")" > /dev/null 2>&1 ;;
+    vim) curl -sL "$feed" > "/tmp/$(echo "$feed" | sed "s/.*\///;s/%20/ /g")" && setsid -f "$TERMINAL" -e "$EDITOR" "/tmp/$(echo "$feed" | sed "s/.*\///;s/%20/ /g")" > /dev/null 2>&1 ;;
+    setbg)
+        curl -L "$feed" > $XDG_CACHE_HOME/pic
+        xwallpaper --zoom $XDG_CACHE_HOME/pic > /dev/null 2>&1
+        ;;
+    browser) setsid -f "$BROWSER" "$feed" > /dev/null 2>&1 ;;
+    lynx) lynx "$feed" > /dev/null 2>&1 ;;
 esac

--- a/.local/bin/dmenumount
+++ b/.local/bin/dmenumount
@@ -5,63 +5,68 @@
 # be prompted to give a mountpoint from already existsing directories. If you
 # input a novel directory, it will prompt you to create that directory.
 
-getmount() { \
-	[ -z "$chosen" ] && exit 1
-        # shellcheck disable=SC2086
-	mp="$(find $1 2>/dev/null | dmenu -i -p "Type in mount point.")" || exit 1
-	[ "$mp" = "" ] && exit 1
-	if [ ! -d "$mp" ]; then
-		mkdiryn=$(printf "No\\nYes" | dmenu -i -p "$mp does not exist. Create it?") || exit 1
-		[ "$mkdiryn" = "Yes" ] && (mkdir -p "$mp" || sudo -A mkdir -p "$mp")
-	fi
-	}
+getmount() {
+    [ -z "$chosen" ] && exit 1
+    # shellcheck disable=SC2086
+    mp="$(find $1 2> /dev/null | dmenu -i -p "Type in mount point.")" || exit 1
+    [ "$mp" = "" ] && exit 1
+    if [ ! -d "$mp" ]; then
+        mkdiryn=$(printf 'No\nYes' | dmenu -i -p "$mp does not exist. Create it?") || exit 1
+        [ "$mkdiryn" = "Yes" ] && (mkdir -p "$mp" || sudo -A mkdir -p "$mp")
+    fi
+}
 
-mountusb() { \
-	chosen="$(echo "$usbdrives" | dmenu -i -p "Mount which drive?")" || exit 1
-	chosen="$(echo "$chosen" | awk '{print $1}')"
-	sudo -A mount "$chosen" 2>/dev/null && notify-send "💻 USB mounting" "$chosen mounted." && exit 0
-	alreadymounted=$(lsblk -nrpo "name,type,mountpoint" | awk '$3!~/\/boot|\/home$|SWAP/&&length($3)>1{printf "-not ( -path *%s -prune ) ",$3}')
-	getmount "/mnt /media /mount /home -maxdepth 5 -type d $alreadymounted"
-	partitiontype="$(lsblk -no "fstype" "$chosen")"
-	case "$partitiontype" in
-		"vfat") sudo -A mount -t vfat "$chosen" "$mp" -o rw,umask=0000;;
-		"exfat") sudo -A mount "$chosen" "$mp" -o uid="$(id -u)",gid="$(id -g)";;
-		*) sudo -A mount "$chosen" "$mp"; user="$(whoami)"; ug="$(groups | awk '{print $1}')"; sudo -A chown "$user":"$ug" "$mp";;
-	esac
-	notify-send "💻 USB mounting" "$chosen mounted to $mp."
-	}
+mountusb() {
+    chosen="$(echo "$usbdrives" | dmenu -i -p "Mount which drive?")" || exit 1
+    chosen="$(echo "$chosen" | awk '{print $1}')"
+    sudo -A mount "$chosen" 2> /dev/null && notify-send "💻 USB mounting" "$chosen mounted." && exit 0
+    alreadymounted=$(lsblk -nrpo "name,type,mountpoint" | awk '$3!~/\/boot|\/home$|SWAP/&&length($3)>1{printf "-not ( -path *%s -prune ) ",$3}')
+    getmount "/mnt /media /mount /home -maxdepth 5 -type d $alreadymounted"
+    partitiontype="$(lsblk -no "fstype" "$chosen")"
+    case "$partitiontype" in
+        "vfat") sudo -A mount -t vfat "$chosen" "$mp" -o rw,umask=0000 ;;
+        "exfat") sudo -A mount "$chosen" "$mp" -o uid="$(id -u)",gid="$(id -g)" ;;
+        *)
+            sudo -A mount "$chosen" "$mp"
+            user="$(whoami)"
+            ug="$(groups | awk '{print $1}')"
+            sudo -A chown "$user":"$ug" "$mp"
+            ;;
+    esac
+    notify-send "💻 USB mounting" "$chosen mounted to $mp."
+}
 
-mountandroid() { \
-	chosen="$(echo "$anddrives" | dmenu -i -p "Which Android device?")" || exit 1
-	chosen="$(echo "$chosen" | cut -d : -f 1)"
-	getmount "$HOME -maxdepth 3 -type d"
-        simple-mtpfs --device "$chosen" "$mp"
-	echo "OK" | dmenu -i -p "Tap Allow on your phone if it asks for permission and then press enter" || exit 1
-	simple-mtpfs --device "$chosen" "$mp"
-	notify-send "🤖 Android Mounting" "Android device mounted to $mp."
-	}
+mountandroid() {
+    chosen="$(echo "$anddrives" | dmenu -i -p "Which Android device?")" || exit 1
+    chosen="$(echo "$chosen" | cut -d : -f 1)"
+    getmount "$HOME -maxdepth 3 -type d"
+    simple-mtpfs --device "$chosen" "$mp"
+    echo "OK" | dmenu -i -p "Tap Allow on your phone if it asks for permission and then press enter" || exit 1
+    simple-mtpfs --device "$chosen" "$mp"
+    notify-send "🤖 Android Mounting" "Android device mounted to $mp."
+}
 
-asktype() { \
-	choice="$(printf "USB\\nAndroid" | dmenu -i -p "Mount a USB drive or Android device?")" || exit 1
-	case $choice in
-		USB) mountusb ;;
-		Android) mountandroid ;;
-	esac
-	}
+asktype() {
+    choice="$(printf 'USB\nAndroid' | dmenu -i -p "Mount a USB drive or Android device?")" || exit 1
+    case $choice in
+        USB) mountusb ;;
+        Android) mountandroid ;;
+    esac
+}
 
-anddrives=$(simple-mtpfs -l 2>/dev/null)
+anddrives=$(simple-mtpfs -l 2> /dev/null)
 usbdrives="$(lsblk -rpo "name,type,size,mountpoint" | grep 'part\|rom' | awk '$4==""{printf "%s (%s)\n",$1,$3}')"
 
 if [ -z "$usbdrives" ]; then
-	[ -z "$anddrives" ] && echo "No USB drive or Android device detected" && exit
-	echo "Android device(s) detected."
-	mountandroid
+    [ -z "$anddrives" ] && echo "No USB drive or Android device detected" && exit
+    echo "Android device(s) detected."
+    mountandroid
 else
-	if [ -z "$anddrives" ]; then
-		echo "USB drive(s) detected."
-		mountusb
-	else
-		echo "Mountable USB drive(s) and Android device(s) detected."
-		asktype
-	fi
+    if [ -z "$anddrives" ]; then
+        echo "USB drive(s) detected."
+        mountusb
+    else
+        echo "Mountable USB drive(s) and Android device(s) detected."
+        asktype
+    fi
 fi

--- a/.local/bin/dmenumountcifs
+++ b/.local/bin/dmenumountcifs
@@ -11,9 +11,10 @@ share=$(smbclient -L "$srvname" -N | grep Disk | awk '{print $1}' | dmenu -i -p 
 share2mnt=//"$srvname".local/"$share"
 
 sharemount() {
-	mounted=$(mount -v | grep "$share2mnt") || ([ ! -d /mnt/"$share" ] && sudo mkdir /mnt/"$share")
-	[ -z "$mounted" ] && sudo mount -t cifs "$share2mnt" -o user=nobody,password="",noperm /mnt/"$share" && notify-send "Netshare $share mounted" && exit 0
-	notify-send "Netshare $share already mounted"; exit 1
+    mounted=$(mount -v | grep "$share2mnt") || ([ ! -d /mnt/"$share" ] && sudo mkdir /mnt/"$share")
+    [ -z "$mounted" ] && sudo mount -t cifs "$share2mnt" -o user=nobody,password="",noperm /mnt/"$share" && notify-send "Netshare $share mounted" && exit 0
+    notify-send "Netshare $share already mounted"
+    exit 1
 }
 
 sharemount

--- a/.local/bin/dmenurecord
+++ b/.local/bin/dmenurecord
@@ -9,115 +9,116 @@
 #
 # If there is already a running instance, user will be prompted to end it.
 
-updateicon() { \
-	echo "$1" > /tmp/recordingicon
-	pkill -RTMIN+9 "${STATUSBAR:-dwmblocks}"
-	}
+updateicon() {
+    echo "$1" > /tmp/recordingicon
+    pkill -RTMIN+9 "${STATUSBAR:-dwmblocks}"
+}
 
 killrecording() {
-	recpid="$(cat /tmp/recordingpid)"
-	# kill with SIGTERM, allowing finishing touches.
-	kill -15 "$recpid"
-	rm -f /tmp/recordingpid
-	updateicon ""
-	pkill -RTMIN+9 "${STATUSBAR:-dwmblocks}"
-	# even after SIGTERM, ffmpeg may still run, so SIGKILL it.
-	sleep 3
-	kill -9 "$recpid"
-	exit
-	}
+    recpid="$(cat /tmp/recordingpid)"
+    # kill with SIGTERM, allowing finishing touches.
+    kill -15 "$recpid"
+    rm -f /tmp/recordingpid
+    updateicon ""
+    pkill -RTMIN+9 "${STATUSBAR:-dwmblocks}"
+    # even after SIGTERM, ffmpeg may still run, so SIGKILL it.
+    sleep 3
+    kill -9 "$recpid"
+    exit
+}
 
-screencast() { \
-	ffmpeg -y \
-	-f x11grab \
-	-framerate 60 \
-	-s "$(xdpyinfo | grep dimensions | awk '{print $2;}')" \
-	-i "$DISPLAY" \
-	-f alsa -i default \
-	-r 30 \
- 	-c:v h264 -crf 0 -preset ultrafast -c:a aac \
-	"$HOME/screencast-$(date '+%y%m%d-%H%M-%S').mp4" &
-	echo $! > /tmp/recordingpid
-	updateicon "⏺️🎙️"
-       	}
+screencast() {
+    ffmpeg -y \
+        -f x11grab \
+        -framerate 60 \
+        -s "$(xdpyinfo | grep dimensions | awk '{print $2;}')" \
+        -i "$DISPLAY" \
+        -f alsa -i default \
+        -r 30 \
+        -c:v h264 -crf 0 -preset ultrafast -c:a aac \
+        "$HOME/screencast-$(date '+%y%m%d-%H%M-%S').mp4" &
+    echo $! > /tmp/recordingpid
+    updateicon "⏺️🎙️"
+}
 
-video() { ffmpeg \
-	-f x11grab \
-	-s "$(xdpyinfo | grep dimensions | awk '{print $2;}')" \
-	-i "$DISPLAY" \
- 	-c:v libx264 -qp 0 -r 30 \
-	"$HOME/video-$(date '+%y%m%d-%H%M-%S').mkv" &
-	echo $! > /tmp/recordingpid
-	updateicon "⏺️"
-	}
+video() {
+    ffmpeg \
+        -f x11grab \
+        -s "$(xdpyinfo | grep dimensions | awk '{print $2;}')" \
+        -i "$DISPLAY" \
+        -c:v libx264 -qp 0 -r 30 \
+        "$HOME/video-$(date '+%y%m%d-%H%M-%S').mkv" &
+    echo $! > /tmp/recordingpid
+    updateicon "⏺️"
+}
 
-webcamhidef() { ffmpeg \
-	-f v4l2 \
-	-i /dev/video0 \
-	-video_size 1920x1080 \
-	"$HOME/webcam-$(date '+%y%m%d-%H%M-%S').mkv" &
-	echo $! > /tmp/recordingpid
-	updateicon "🎥"
-	}
+webcamhidef() {
+    ffmpeg \
+        -f v4l2 \
+        -i /dev/video0 \
+        -video_size 1920x1080 \
+        "$HOME/webcam-$(date '+%y%m%d-%H%M-%S').mkv" &
+    echo $! > /tmp/recordingpid
+    updateicon "🎥"
+}
 
-webcam() { ffmpeg \
-	-f v4l2 \
-	-i /dev/video0 \
-	-video_size 640x480 \
-	"$HOME/webcam-$(date '+%y%m%d-%H%M-%S').mkv" &
-	echo $! > /tmp/recordingpid
-	updateicon "🎥"
-	}
+webcam() {
+    ffmpeg \
+        -f v4l2 \
+        -i /dev/video0 \
+        -video_size 640x480 \
+        "$HOME/webcam-$(date '+%y%m%d-%H%M-%S').mkv" &
+    echo $! > /tmp/recordingpid
+    updateicon "🎥"
+}
 
+audio() {
+    ffmpeg \
+        -f alsa -i default \
+        -c:a flac \
+        "$HOME/audio-$(date '+%y%m%d-%H%M-%S').flac" &
+    echo $! > /tmp/recordingpid
+    updateicon "🎙️"
+}
 
-audio() { \
-	ffmpeg \
-	-f alsa -i default \
-	-c:a flac \
-	"$HOME/audio-$(date '+%y%m%d-%H%M-%S').flac" &
-	echo $! > /tmp/recordingpid
-	updateicon "🎙️"
-	}
+askrecording() {
+    choice=$(printf 'screencast\nvideo\nvideo selected\naudio\nwebcam\nwebcam (hi-def)' | dmenu -i -p "Select recording style:")
+    case "$choice" in
+        screencast) screencast ;;
+        audio) audio ;;
+        video) video ;;
+        *selected) videoselected ;;
+        webcam) webcam ;;
+        "webcam (hi-def)") webcamhidef ;;
+    esac
+}
 
-askrecording() { \
-	choice=$(printf "screencast\\nvideo\\nvideo selected\\naudio\\nwebcam\\nwebcam (hi-def)" | dmenu -i -p "Select recording style:")
-	case "$choice" in
-		screencast) screencast;;
-		audio) audio;;
-		video) video;;
-		*selected) videoselected;;
-		webcam) webcam;;
-		"webcam (hi-def)") webcamhidef;;
-	esac
-	}
+asktoend() {
+    response=$(printf 'No\nYes' | dmenu -i -p "Recording still active. End recording?") \
+        && [ "$response" = "Yes" ] && killrecording
+}
 
-asktoend() { \
-	response=$(printf "No\\nYes" | dmenu -i -p "Recording still active. End recording?") &&
-	[ "$response" = "Yes" ] &&  killrecording
-	}
+videoselected() {
+    slop -f "%x %y %w %h" > /tmp/slop
+    read -r X Y W H < /tmp/slop
+    rm /tmp/slop
 
-videoselected()
-{
-	slop -f "%x %y %w %h" > /tmp/slop
-	read -r X Y W H < /tmp/slop
-	rm /tmp/slop
-
-	ffmpeg \
-	-f x11grab \
-	-framerate 60 \
-	-video_size "$W"x"$H" \
-	-i :0.0+"$X,$Y" \
-	-c:v libx264 -qp 0 -r 30 \
-	"$HOME/box-$(date '+%y%m%d-%H%M-%S').mkv" &
-	echo $! > /tmp/recordingpid
-	updateicon "⏺️"
+    ffmpeg \
+        -f x11grab \
+        -framerate 60 \
+        -video_size "$W"x"$H" \
+        -i :0.0+"$X,$Y" \
+        -c:v libx264 -qp 0 -r 30 \
+        "$HOME/box-$(date '+%y%m%d-%H%M-%S').mkv" &
+    echo $! > /tmp/recordingpid
+    updateicon "⏺️"
 }
 
 case "$1" in
-	screencast) screencast;;
-	audio) audio;;
-	video) video;;
-	*selected) videoselected;;
-	kill) killrecording;;
-	*) ([ -f /tmp/recordingpid ] && asktoend && exit) || askrecording;;
+    screencast) screencast ;;
+    audio) audio ;;
+    video) video ;;
+    *selected) videoselected ;;
+    kill) killrecording ;;
+    *) ([ -f /tmp/recordingpid ] && asktoend && exit) || askrecording ;;
 esac

--- a/.local/bin/dmenuumount
+++ b/.local/bin/dmenuumount
@@ -5,40 +5,39 @@
 # Drives mounted at /, /boot and /home will not be options to unmount.
 
 unmountusb() {
-	[ -z "$drives" ] && exit
-	chosen="$(echo "$drives" | dmenu -i -p "Unmount which drive?")" || exit 1
-	chosen="$(echo "$chosen" | awk '{print $1}')"
-	[ -z "$chosen" ] && exit
-	sudo -A umount "$chosen" && notify-send "💻 USB unmounting" "$chosen unmounted."
-	}
+    [ -z "$drives" ] && exit
+    chosen="$(echo "$drives" | dmenu -i -p "Unmount which drive?")" || exit 1
+    chosen="$(echo "$chosen" | awk '{print $1}')"
+    [ -z "$chosen" ] && exit
+    sudo -A umount "$chosen" && notify-send "💻 USB unmounting" "$chosen unmounted."
+}
 
-unmountandroid() { \
-	chosen="$(awk '/simple-mtpfs/ {print $2}' /etc/mtab | dmenu -i -p "Unmount which device?")" || exit 1
-	[ -z "$chosen" ] && exit
-	sudo -A umount -l "$chosen" && notify-send "🤖 Android unmounting" "$chosen unmounted."
-	}
+unmountandroid() {
+    chosen="$(awk '/simple-mtpfs/ {print $2}' /etc/mtab | dmenu -i -p "Unmount which device?")" || exit 1
+    [ -z "$chosen" ] && exit
+    sudo -A umount -l "$chosen" && notify-send "🤖 Android unmounting" "$chosen unmounted."
+}
 
-asktype() { \
-	choice="$(printf "USB\\nAndroid" | dmenu -i -p "Unmount a USB drive or Android device?")" || exit 1
-	case "$choice" in
-		USB) unmountusb ;;
-		Android) unmountandroid ;;
-	esac
-	}
+asktype() {
+    choice="$(printf 'USB\nAndroid' | dmenu -i -p "Unmount a USB drive or Android device?")" || exit 1
+    case "$choice" in
+        USB) unmountusb ;;
+        Android) unmountandroid ;;
+    esac
+}
 
 drives=$(lsblk -nrpo "name,type,size,mountpoint" | awk '$4!~/\/boot|\/home$|SWAP/&&length($4)>1{printf "%s (%s)\n",$4,$3}')
 
 if ! grep simple-mtpfs /etc/mtab; then
-	[ -z "$drives" ] && echo "No drives to unmount." &&  exit
-	echo "Unmountable USB drive detected."
-	unmountusb
+    [ -z "$drives" ] && echo "No drives to unmount." && exit
+    echo "Unmountable USB drive detected."
+    unmountusb
 else
-	if [ -z "$drives" ]
-	then
-		echo "Unmountable Android device detected."
-	       	unmountandroid
-	else
-		echo "Unmountable USB drive(s) and Android device(s) detected."
-		asktype
-	fi
+    if [ -z "$drives" ]; then
+        echo "Unmountable Android device detected."
+        unmountandroid
+    else
+        echo "Unmountable USB drive(s) and Android device(s) detected."
+        asktype
+    fi
 fi

--- a/.local/bin/dmenuunicode
+++ b/.local/bin/dmenuunicode
@@ -11,8 +11,8 @@ chosen=$(cut -d ';' -f1 ~/.local/share/larbs/emoji | dmenu -i -l 30 | sed "s/ .*
 # If you run this command with an argument, it will automatically insert the
 # character. Otherwise, show a message that the emoji has been copied.
 if [ -n "$1" ]; then
-	xdotool type "$chosen"
+    xdotool type "$chosen"
 else
-	printf "$chosen" | xclip -selection clipboard
-	notify-send "'$chosen' copied to clipboard." &
+    printf "$chosen" | xclip -selection clipboard
+    notify-send "'$chosen' copied to clipboard." &
 fi

--- a/.local/bin/ext
+++ b/.local/bin/ext
@@ -7,39 +7,39 @@
 # Behavior with `-c` option: Extract contents into current directory
 
 while getopts "hc" o; do case "${o}" in
-	c) extracthere="True" ;;
-	*) printf "Options:\\n   -c: Extract archive into current directory rather than a new one.\\n" && exit 1 ;;
-esac done
+    c) extracthere="True" ;;
+    *) printf 'Options:\n   -c: Extract archive into current directory rather than a new one.\n' && exit 1 ;;
+esac; done
 
 if [ -z "$extracthere" ]; then
-	archive="$(readlink -f "$*")" &&
-	directory="$(echo "$archive" | sed 's/\.[^\/.]*$//')" &&
-	mkdir -p "$directory" &&
-	cd "$directory" || exit 1
+    archive="$(readlink -f "$*")" \
+        && directory="$(echo "$archive" | sed 's/\.[^\/.]*$//')" \
+        && mkdir -p "$directory" \
+        && cd "$directory" || exit 1
 else
-	archive="$(readlink -f "$(echo "$*" | cut -d' ' -f2)" 2>/dev/null)"
+    archive="$(readlink -f "$(echo "$*" | cut -d' ' -f2)" 2> /dev/null)"
 fi
 
-[ -z "$archive" ] && printf "Give archive to extract as argument.\\n" && exit 1
+[ -z "$archive" ] && printf 'Give archive to extract as argument.\n' && exit 1
 
-if [ -f "$archive" ] ; then
-	case "$archive" in
-		*.tar.bz2|*.tbz2) tar xvjf "$archive" ;;
-		*.tar.xz) tar -xf "$archive" ;;
-		*.tar.gz|*.tgz) tar xvzf "$archive" ;;
-		*.tar.zst) tar -I zstd -xf "$archive" ;;
-		*.lzma) unlzma "$archive" ;;
-		*.bz2) bunzip2 "$archive" ;;
-		*.rar) unrar x -ad "$archive" ;;
-		*.gz) gunzip "$archive" ;;
-		*.tar) tar xvf "$archive" ;;
-		*.zip) unzip "$archive" ;;
-		*.Z) uncompress "$archive" ;;
-		*.7z) 7z x "$archive" ;;
-		*.xz) unxz "$archive" ;;
-		*.exe) cabextract "$archive" ;;
-		*) printf "extract: '%s' - unknown archive method\\n" "$archive" ;;
-	esac
+if [ -f "$archive" ]; then
+    case "$archive" in
+        *.tar.bz2 | *.tbz2) tar xvjf "$archive" ;;
+        *.tar.xz) tar -xf "$archive" ;;
+        *.tar.gz | *.tgz) tar xvzf "$archive" ;;
+        *.tar.zst) tar -I zstd -xf "$archive" ;;
+        *.lzma) unlzma "$archive" ;;
+        *.bz2) bunzip2 "$archive" ;;
+        *.rar) unrar x -ad "$archive" ;;
+        *.gz) gunzip "$archive" ;;
+        *.tar) tar xvf "$archive" ;;
+        *.zip) unzip "$archive" ;;
+        *.Z) uncompress "$archive" ;;
+        *.7z) 7z x "$archive" ;;
+        *.xz) unxz "$archive" ;;
+        *.exe) cabextract "$archive" ;;
+        *) printf "extract: '%s' - unknown archive method\\n" "$archive" ;;
+    esac
 else
-	printf "File \"%s\" not found.\\n" "$archive"
+    printf 'File "%s" not found.\n' "$archive"
 fi

--- a/.local/bin/getbib
+++ b/.local/bin/getbib
@@ -2,13 +2,13 @@
 [ -z "$1" ] && echo "Give either a pdf file or a DOI as an argument." && exit
 
 if [ -f "$1" ]; then
-	# Try to get DOI from pdfinfo or pdftotext output.
-	doi=$(pdfinfo "$1" | grep -io "doi:.*") ||
-	doi=$(pdftotext "$1" 2>/dev/null - | grep -io "doi:.*" -m 1) ||
-	exit 1
+    # Try to get DOI from pdfinfo or pdftotext output.
+    doi=$(pdfinfo "$1" | grep -io "doi:.*") \
+        || doi=$(pdftotext "$1" - 2> /dev/null | grep -io "doi:.*" -m 1) \
+        || exit 1
 else
-	doi="$1"
+    doi="$1"
 fi
 
 # Check crossref.org for the bib citation.
-curl -s "http://api.crossref.org/works/$doi/transform/application/x-bibtex" -w "\\n"
+curl -s "http://api.crossref.org/works/$doi/transform/application/x-bibtex" -w '\n'

--- a/.local/bin/getkeys
+++ b/.local/bin/getkeys
@@ -1,5 +1,5 @@
 #!/bin/sh
 
-cat "${XDG_DATA_HOME:-$HOME/.local/share}"/larbs/getkeys/"$1" 2>/dev/null && exit
+cat "${XDG_DATA_HOME:-$HOME/.local/share}"/larbs/getkeys/"$1" 2> /dev/null && exit
 echo "Run command with one of the following arguments for info about that program:"
 ls "${XDG_DATA_HOME:-$HOME/.local/share}"/larbs/getkeys

--- a/.local/bin/ifinstalled
+++ b/.local/bin/ifinstalled
@@ -5,7 +5,7 @@
 # it informs the user that they need that command to continue. This is used in
 # various other scripts for clarity's sake.
 
-for x in "$@";do
-	pacman -Qq "$x" >/dev/null 2>&1 ||
-		{ notify-send "📦 $x" "must be installed for this function." && exit 1 ;}
+for x in "$@"; do
+    pacman -Qq "$x" > /dev/null 2>&1 \
+        || { notify-send "📦 $x" "must be installed for this function." && exit 1; }
 done

--- a/.local/bin/lf-select
+++ b/.local/bin/lf-select
@@ -3,7 +3,7 @@
 # Reads file names from stdin and selects them in lf.
 
 while read -r file; do
-	[ -z "$file" ] && continue
-	lf -remote "send select \"$file\""
-	lf -remote "send toggle"
+    [ -z "$file" ] && continue
+    lf -remote "send select \"$file\""
+    lf -remote "send toggle"
 done

--- a/.local/bin/linkhandler
+++ b/.local/bin/linkhandler
@@ -7,17 +7,25 @@
 # otherwise it opens link in browser.
 
 # If no url given. Opens browser. For using script as $BROWSER.
-[ -z "$1" ] && { "$BROWSER"; exit; }
+[ -z "$1" ] && {
+    "$BROWSER"
+    exit
+}
 
 case "$1" in
-	*mkv|*webm|*mp4|*youtube.com/watch*|*youtube.com/playlist*|*youtu.be*|*hooktube.com*|*bitchute.com*|*videos.lukesmith.xyz*)
-		setsid -f mpv -quiet "$1" >/dev/null 2>&1 ;;
-	*png|*jpg|*jpe|*jpeg|*gif)
-		curl -sL "$1" > "/tmp/$(echo "$1" | sed "s/.*\///;s/%20/ /g")" && sxiv -a "/tmp/$(echo "$1" | sed "s/.*\///;s/%20/ /g")"  >/dev/null 2>&1 & ;;
-	*pdf|*cbz|*cbr)
-		curl -sL "$1" > "/tmp/$(echo "$1" | sed "s/.*\///;s/%20/ /g")" && zathura "/tmp/$(echo "$1" | sed "s/.*\///;s/%20/ /g")"  >/dev/null 2>&1 & ;;
-	*mp3|*flac|*opus|*mp3?source*)
-		qndl "$1" 'curl -LO'  >/dev/null 2>&1 ;;
-	*)
-		[ -f "$1" ] && setsid -f "$TERMINAL" -e "$EDITOR" "$1" >/dev/null 2>&1 || setsid -f "$BROWSER" "$1" >/dev/null 2>&1
+    *mkv | *webm | *mp4 | *youtube.com/watch* | *youtube.com/playlist* | *youtu.be* | *hooktube.com* | *bitchute.com* | *videos.lukesmith.xyz*)
+        setsid -f mpv -quiet "$1" > /dev/null 2>&1
+        ;;
+    *png | *jpg | *jpe | *jpeg | *gif)
+        curl -sL "$1" > "/tmp/$(echo "$1" | sed "s/.*\///;s/%20/ /g")" && sxiv -a "/tmp/$(echo "$1" | sed "s/.*\///;s/%20/ /g")" > /dev/null 2>&1 &
+        ;;
+    *pdf | *cbz | *cbr)
+        curl -sL "$1" > "/tmp/$(echo "$1" | sed "s/.*\///;s/%20/ /g")" && zathura "/tmp/$(echo "$1" | sed "s/.*\///;s/%20/ /g")" > /dev/null 2>&1 &
+        ;;
+    *mp3 | *flac | *opus | *mp3?source*)
+        qndl "$1" 'curl -LO' > /dev/null 2>&1
+        ;;
+    *)
+        [ -f "$1" ] && setsid -f "$TERMINAL" -e "$EDITOR" "$1" > /dev/null 2>&1 || setsid -f "$BROWSER" "$1" > /dev/null 2>&1
+        ;;
 esac

--- a/.local/bin/maimpick
+++ b/.local/bin/maimpick
@@ -4,11 +4,11 @@
 # choose the kind of screenshot to take, including copying the image or even
 # highlighting an area to copy. scrotcucks on suicidewatch right now.
 
-case "$(printf "a selected area\\ncurrent window\\nfull screen\\na selected area (copy)\\ncurrent window (copy)\\nfull screen (copy)" | dmenu -l 6 -i -p "Screenshot which area?")" in
-	"a selected area") maim -s pic-selected-"$(date '+%y%m%d-%H%M-%S').png" ;;
-	"current window") maim -i "$(xdotool getactivewindow)" pic-window-"$(date '+%y%m%d-%H%M-%S').png" ;;
-	"full screen") maim pic-full-"$(date '+%y%m%d-%H%M-%S').png" ;;
-	"a selected area (copy)") maim -s | xclip -selection clipboard -t image/png ;;
-	"current window (copy)") maim -i "$(xdotool getactivewindow)" | xclip -selection clipboard -t image/png ;;
-	"full screen (copy)") maim | xclip -selection clipboard -t image/png ;;
+case "$(printf 'a selected area\ncurrent window\nfull screen\na selected area (copy)\ncurrent window (copy)\nfull screen (copy)' | dmenu -l 6 -i -p "Screenshot which area?")" in
+    "a selected area") maim -s pic-selected-"$(date '+%y%m%d-%H%M-%S').png" ;;
+    "current window") maim -i "$(xdotool getactivewindow)" pic-window-"$(date '+%y%m%d-%H%M-%S').png" ;;
+    "full screen") maim pic-full-"$(date '+%y%m%d-%H%M-%S').png" ;;
+    "a selected area (copy)") maim -s | xclip -selection clipboard -t image/png ;;
+    "current window (copy)") maim -i "$(xdotool getactivewindow)" | xclip -selection clipboard -t image/png ;;
+    "full screen (copy)") maim | xclip -selection clipboard -t image/png ;;
 esac

--- a/.local/bin/opout
+++ b/.local/bin/opout
@@ -7,7 +7,7 @@
 basename="$(echo "${*}" | sed 's/\.[^\/.]*$//')"
 
 case "${*}" in
-	*.tex|*.m[dse]|*.[rR]md|*.mom|*.[0-9]) setsid -f xdg-open "$basename".pdf >/dev/null 2>&1 ;;
-	*.html) setsid -f "$BROWSER" "$basename".html >/dev/null 2>&1 ;;
-	*.sent) setsid -f sent "$1" >/dev/null 2>&1 ;;
+    *.tex | *.m[dse] | *.[rR]md | *.mom | *.[0-9]) setsid -f xdg-open "$basename".pdf > /dev/null 2>&1 ;;
+    *.html) setsid -f "$BROWSER" "$basename".html > /dev/null 2>&1 ;;
+    *.sent) setsid -f sent "$1" > /dev/null 2>&1 ;;
 esac

--- a/.local/bin/pauseallmpv
+++ b/.local/bin/pauseallmpv
@@ -6,5 +6,5 @@
 # (with other things) by default and is used in some other places.
 
 for i in $(ls /tmp/mpvSockets/*); do
-	echo '{ "command": ["set_property", "pause", true] }' | socat - "$i";
+    echo '{ "command": ["set_property", "pause", true] }' | socat - "$i"
 done

--- a/.local/bin/podentr
+++ b/.local/bin/podentr
@@ -4,4 +4,4 @@
 
 [ "$(pgrep -x "$(basename "$0")" | wc -l)" -gt 2 ] && exit
 
-echo "${XDG_DATA_HOME:-$HOME/.local/share}"/newsboat/queue | entr -p queueandnotify 2>/dev/null
+echo "${XDG_DATA_HOME:-$HOME/.local/share}"/newsboat/queue | entr -p queueandnotify 2> /dev/null

--- a/.local/bin/prompt
+++ b/.local/bin/prompt
@@ -5,4 +5,4 @@
 # For example:
 # `./prompt "Do you want to shutdown?" "shutdown -h now"`
 
-[ "$(printf "No\\nYes" | dmenu -i -p "$1" -nb darkred -sb red -sf white -nf gray )" = "Yes" ] && $2
+[ "$(printf 'No\nYes' | dmenu -i -p "$1" -nb darkred -sb red -sf white -nf gray)" = "Yes" ] && $2

--- a/.local/bin/queueandnotify
+++ b/.local/bin/queueandnotify
@@ -6,9 +6,9 @@
 queuefile="${XDG_DATA_HOME:-$HOME/.local/share}/newsboat/queue"
 
 while read -r line; do
-	[ -z "$line" ] && continue
-	url="$(echo "$line" | awk '{print $1}')"
-	qndl "$url" "curl -LO"
+    [ -z "$line" ] && continue
+    url="$(echo "$line" | awk '{print $1}')"
+    qndl "$url" "curl -LO"
 done < "$queuefile"
 
 echo > "$queuefile"

--- a/.local/bin/remaps
+++ b/.local/bin/remaps
@@ -6,7 +6,8 @@ xset r rate 300 50
 # Map the caps lock key to super...
 setxkbmap -option caps:super
 # But when it is pressed only once, treat it as escape.
-killall xcape 2>/dev/null ; xcape -e 'Super_L=Escape'
+killall xcape 2> /dev/null
+xcape -e 'Super_L=Escape'
 # Map the menu button to right super as well.
 xmodmap -e 'keycode 135 = Super_R'
 # Turn off the caps lock if on since there is no longer a key for it.

--- a/.local/bin/rssadd
+++ b/.local/bin/rssadd
@@ -1,10 +1,10 @@
 #!/bin/sh
 
-! echo "$1" | grep "https*://\S\+\.[A-Za-z]\+\S*" >/dev/null &&
-	notify-send "That doesn't look like a full URL." && exit
+! echo "$1" | grep "https*://\S\+\.[A-Za-z]\+\S*" > /dev/null \
+    && notify-send "That doesn't look like a full URL." && exit
 RSSFILE="${XDG_CONFIG_HOME:-$HOME/.config}/newsboat/urls"
-if awk '{print $1}' "$RSSFILE" | grep "^$1$" >/dev/null; then
-	notify-send "You already have this RSS feed."
+if awk '{print $1}' "$RSSFILE" | grep "^$1$" > /dev/null; then
+    notify-send "You already have this RSS feed."
 else
-	echo "$1" >> "$RSSFILE" && notify-send "RSS feed added."
+    echo "$1" >> "$RSSFILE" && notify-send "RSS feed added."
 fi

--- a/.local/bin/setbg
+++ b/.local/bin/setbg
@@ -9,16 +9,19 @@
 # Location of link to wallpaper link.
 bgloc="${XDG_DATA_HOME:-$HOME/.local/share/}/bg"
 
-trueloc="$(readlink -f "$1")" &&
-case "$(file --mime-type -b "$trueloc")" in
-	image/* ) ln -sf "$(readlink -f "$1")" "$bgloc" && notify-send -i "$bgloc" "Changing wallpaper..." ;;
-	inode/directory ) ln -sf "$(find "$trueloc" -iregex '.*.\(jpg\|jpeg\|png\|gif\)' -type f | shuf -n 1)" "$bgloc" && notify-send -i "$bgloc" "Random Wallpaper chosen." ;;
-	*) notify-send "Error" "Not a valid image." ; exit 1;;
-esac
+trueloc="$(readlink -f "$1")" \
+    && case "$(file --mime-type -b "$trueloc")" in
+        image/*) ln -sf "$(readlink -f "$1")" "$bgloc" && notify-send -i "$bgloc" "Changing wallpaper..." ;;
+        inode/directory) ln -sf "$(find "$trueloc" -iregex '.*.\(jpg\|jpeg\|png\|gif\)' -type f | shuf -n 1)" "$bgloc" && notify-send -i "$bgloc" "Random Wallpaper chosen." ;;
+        *)
+            notify-send "Error" "Not a valid image."
+            exit 1
+            ;;
+    esac
 
 # If pywal is installed, use it.
-command -v wal >/dev/null 2>&1 &&
-	wal -i "$trueloc" -o "${XDG_CONFIG_HOME:-$HOME/.config}/wal/postrun" >/dev/null 2>&1 &&
-	pidof dwm >/dev/null && xdotool key super+F12
+command -v wal > /dev/null 2>&1 \
+    && wal -i "$trueloc" -o "${XDG_CONFIG_HOME:-$HOME/.config}/wal/postrun" > /dev/null 2>&1 \
+    && pidof dwm > /dev/null && xdotool key super+F12
 
 xwallpaper --zoom "$bgloc"

--- a/.local/bin/shortcuts
+++ b/.local/bin/shortcuts
@@ -12,14 +12,14 @@ fish_shortcuts="/dev/null"
 vifm_shortcuts="/dev/null"
 
 # Remove, prepare files
-rm -f "$ranger_shortcuts" "$qute_shortcuts" "$zsh_named_dirs" 2>/dev/null
-printf "# vim: filetype=sh\\n" > "$fish_shortcuts"
-printf "# vim: filetype=sh\\nalias " > "$shell_shortcuts"
-printf "\" vim: filetype=vim\\n" > "$vifm_shortcuts"
+rm -f "$ranger_shortcuts" "$qute_shortcuts" "$zsh_named_dirs" 2> /dev/null
+printf '# vim: filetype=sh\n' > "$fish_shortcuts"
+printf '# vim: filetype=sh\nalias ' > "$shell_shortcuts"
+printf '" vim: filetype=vim\n' > "$vifm_shortcuts"
 
 # Format the `directories` file in the correct syntax and sent it to all three configs.
-eval "echo \"$(cat "$bmdirs")\"" | \
-awk "!/^\s*#/ && !/^\s*\$/ {gsub(\"\\\s*#.*$\",\"\");
+eval "echo \"$(cat "$bmdirs")\"" \
+    | awk "!/^\s*#/ && !/^\s*\$/ {gsub(\"\\\s*#.*$\",\"\");
     printf(\"%s=\42cd %s && ls -a\42 \\\\\n\",\$1,\$2)   >> \"$shell_shortcuts\" ;
     printf(\"hash -d %s=%s \n\",\$1,\$2)                 >> \"$zsh_named_dirs\"  ;
     printf(\"abbr %s \42cd %s; and ls -a\42\n\",\$1,\$2) >> \"$fish_shortcuts\"  ;
@@ -28,8 +28,8 @@ awk "!/^\s*#/ && !/^\s*\$/ {gsub(\"\\\s*#.*$\",\"\");
     printf(\"map g%s cd %s\nmap t%s tab_new %s\nmap m%s shell mv -v %%s %s\nmap Y%s shell cp -rv %%s %s \n\",\$1,\$2,\$1,\$2, \$1, \$2, \$1, \$2) >> \"$ranger_shortcuts\" }"
 
 # Format the `files` file in the correct syntax and sent it to both configs.
-eval "echo \"$(cat "$bmfiles")\"" | \
-awk "!/^\s*#/ && !/^\s*\$/ {gsub(\"\\\s*#.*$\",\"\");
+eval "echo \"$(cat "$bmfiles")\"" \
+    | awk "!/^\s*#/ && !/^\s*\$/ {gsub(\"\\\s*#.*$\",\"\");
     printf(\"%s=\42\$EDITOR %s\42 \\\\\n\",\$1,\$2)  >> \"$shell_shortcuts\" ;
     printf(\"hash -d %s=%s \n\",\$1,\$2)             >> \"$zsh_named_dirs\"  ;
 	printf(\"abbr %s \42\$EDITOR %s\42 \n\",\$1,\$2) >> \"$fish_shortcuts\"  ;

--- a/.local/bin/slider
+++ b/.local/bin/slider
@@ -10,25 +10,29 @@
 cache="${XDG_CACHE_HOME:-$HOME/.cache}/slider"
 
 while getopts "hvrpi:c:a:o:d:f:t:e:x:" o; do case "${o}" in
-	c) bgc="$OPTARG" ;;
-	t) fgc="$OPTARG" ;;
-	i) file="$OPTARG" ;;
-	a) audio="$OPTARG" ;;
-	o) outfile="$OPTARG" ;;
-	d) prepdir="$OPTARG" ;;
-	r) redo="$OPTARG" ;;
-	s) ppt="$OPTARG" ;;
-	e) endtime="$OPTARG" ;;
-	x) res="$OPTARG"
-		echo "$res" | grep -qv "^[0-9]\+x[0-9]\+$" &&
-			echo "Resolution must be dimensions separated by a 'x': 1280x720, etc." &&
-			exit 1 ;;
-	p) echo "Purge old build files in $cache? [y/N]"
-		read -r confirm
-		echo "$confirm" | grep -iq "^y$" && rm -rf "$cache" && echo "Done."
-		exit ;;
-	v) verbose=True ;;
-	*) echo "$(basename "$0") usage:
+    c) bgc="$OPTARG" ;;
+    t) fgc="$OPTARG" ;;
+    i) file="$OPTARG" ;;
+    a) audio="$OPTARG" ;;
+    o) outfile="$OPTARG" ;;
+    d) prepdir="$OPTARG" ;;
+    r) redo="$OPTARG" ;;
+    s) ppt="$OPTARG" ;;
+    e) endtime="$OPTARG" ;;
+    x)
+        res="$OPTARG"
+        echo "$res" | grep -qv "^[0-9]\+x[0-9]\+$" \
+            && echo "Resolution must be dimensions separated by a 'x': 1280x720, etc." \
+            && exit 1
+        ;;
+    p)
+        echo "Purge old build files in $cache? [y/N]"
+        read -r confirm
+        echo "$confirm" | grep -iq "^y$" && rm -rf "$cache" && echo "Done."
+        exit
+        ;;
+    v) verbose=True ;;
+    *) echo "$(basename "$0") usage:
   -i  input timecode list (required)
   -a  audio file
   -c  color of background (use html names, black is default)
@@ -40,32 +44,35 @@ while getopts "hvrpi:c:a:o:d:f:t:e:x:" o; do case "${o}" in
   -d  tmp directory
   -r  rerun imagemagick commands even if done previously (in case files or background has changed)
   -p  purge old build files instead of running
-  -v  be verbose" && exit 1
+  -v  be verbose" && exit 1 ;;
 
-esac done
+esac; done
 
 # Check that the input file looks like it should.
-{ head -n 1 "$file" 2>/dev/null | grep -q "^00:00:00	" ;} || {
-	echo "Give an input file with -i." &&
-	echo "The file should look as this example:
+{ head -n 1 "$file" 2> /dev/null | grep -q "^00:00:00	"; } || {
+    echo "Give an input file with -i." \
+        && echo "The file should look as this example:
 
 00:00:00	first_image.jpg
 00:00:03	otherdirectory/next_image.jpg
 00:00:09	this_image_starts_at_9_seconds.jpg
 etc...
 
-Timecodes and filenames must be separated by Tabs." &&
-	exit 1
-	}
+Timecodes and filenames must be separated by Tabs." \
+        && exit 1
+}
 
 if [ -n "${audio+x}" ]; then
-	# Check that the audio file looks like an actual audio file.
-	case "$(file --dereference --brief --mime-type -- "$audio")" in
-		audio/*) ;;
-		*) echo "That doesn't look like an audio file."; exit 1 ;;
-	esac
-	totseconds="$(date '+%s' -d $(ffmpeg -i "$audio" 2>&1 | awk '/Duration/ {print $2}' | sed s/,//))"
-	endtime="$((totseconds-seconds))"
+    # Check that the audio file looks like an actual audio file.
+    case "$(file --dereference --brief --mime-type -- "$audio")" in
+        audio/*) ;;
+        *)
+            echo "That doesn't look like an audio file."
+            exit 1
+            ;;
+    esac
+    totseconds="$(date '+%s' -d $(ffmpeg -i "$audio" 2>&1 | awk '/Duration/ {print $2}' | sed s/,//))"
+    endtime="$((totseconds - seconds))"
 fi
 
 prepdir="${prepdir:-$cache/$file}"
@@ -76,47 +83,46 @@ prepfile="$prepdir/$file.prep"
 mkdir -p "$prepdir"
 
 {
-while read -r x;
-do
-	# Get the time from the first column.
-	time="${x%%	*}"
-	seconds="$(date '+%s' -d "$time")"
-	# Duration is not used on the first looped item.
-	duration="$((seconds - prevseconds))"
+    while read -r x; do
+        # Get the time from the first column.
+        time="${x%%	*}"
+        seconds="$(date '+%s' -d "$time")"
+        # Duration is not used on the first looped item.
+        duration="$((seconds - prevseconds))"
 
-	# Get the filename/text content from the rest.
-	content="${x#*	}"
-	base="$(basename "$content")"
-	base="${base%.*}.jpg"
+        # Get the filename/text content from the rest.
+        content="${x#*	}"
+        base="$(basename "$content")"
+        base="${base%.*}.jpg"
 
-	if [ -f "$content" ]; then
-		# If images have already been made in a previous run, do not recreate
-		# them unless -r was given.
-		{ [ ! -f "$prepdir/$base" ] || [ -n "${redo+x}" ] ;} &&
-			convert -size "${res:-1920x1080}" canvas:"${bgc:-black}" -gravity center "$content" -resize 1920x1080 -composite "$prepdir/$base"
-	else
-		{ [ ! -f "$prepdir/$base" ] || [ -n "${redo+x}" ] ;} &&
-			convert -size "${res:-1920x1080}" -background "${bgc:-black}" -fill "${fgc:-white}" -pointsize "${ppt:-150}" -gravity center label:"$content" "$prepdir/$base"
-	fi
+        if [ -f "$content" ]; then
+            # If images have already been made in a previous run, do not recreate
+            # them unless -r was given.
+            { [ ! -f "$prepdir/$base" ] || [ -n "${redo+x}" ]; } \
+                && convert -size "${res:-1920x1080}" canvas:"${bgc:-black}" -gravity center "$content" -resize 1920x1080 -composite "$prepdir/$base"
+        else
+            { [ ! -f "$prepdir/$base" ] || [ -n "${redo+x}" ]; } \
+                && convert -size "${res:-1920x1080}" -background "${bgc:-black}" -fill "${fgc:-white}" -pointsize "${ppt:-150}" -gravity center label:"$content" "$prepdir/$base"
+        fi
 
-	# If the first line, do not write yet.
-	[ "$time" = "00:00:00" ] || echo "file '$prevbase'
+        # If the first line, do not write yet.
+        [ "$time" = "00:00:00" ] || echo "file '$prevbase'
 duration $duration"
 
-	# Keep the information required for the next file.
-	prevbase="$base"
-	prevtime="$time"
-	prevseconds="$(date '+%s' -d "$prevtime")"
-done < "$file"
-# Do last file which must be given twice as follows
-echo "file '$base'
+        # Keep the information required for the next file.
+        prevbase="$base"
+        prevtime="$time"
+        prevseconds="$(date '+%s' -d "$prevtime")"
+    done < "$file"
+    # Do last file which must be given twice as follows
+    echo "file '$base'
 duration ${endtime:-5}
 file '$base'"
 } > "$prepfile"
 if [ -n "${audio+x}" ]; then
-	ffmpeg -hide_banner -y -f concat -safe 0 -i "$prepfile" -i "$audio" -c:a aac -vsync vfr -c:v libx264 -pix_fmt yuv420p "$outfile"
+    ffmpeg -hide_banner -y -f concat -safe 0 -i "$prepfile" -i "$audio" -c:a aac -vsync vfr -c:v libx264 -pix_fmt yuv420p "$outfile"
 else
-	ffmpeg -hide_banner -y -f concat -safe 0 -i "$prepfile" -vsync vfr -c:v libx264 -pix_fmt yuv420p "$outfile"
+    ffmpeg -hide_banner -y -f concat -safe 0 -i "$prepfile" -vsync vfr -c:v libx264 -pix_fmt yuv420p "$outfile"
 fi
 
 # Might also try:

--- a/.local/bin/statusbar/sb-battery
+++ b/.local/bin/statusbar/sb-battery
@@ -4,33 +4,34 @@
 # to charge status (🔌 for plugged up, 🔋 for discharging on battery, etc.).
 
 case $BLOCK_BUTTON in
-	3) notify-send "🔋 Battery module" "🔋: discharging
+    3) notify-send "🔋 Battery module" "🔋: discharging
 🛑: not charging
 ♻: stagnant charge
 🔌: charging
 ⚡: charged
 ❗: battery very low!
 - Scroll to change adjust xbacklight." ;;
-	4) xbacklight -inc 10 ;;
-	5) xbacklight -dec 10 ;;
-	6) "$TERMINAL" -e "$EDITOR" "$0" ;;
+    4) xbacklight -inc 10 ;;
+    5) xbacklight -dec 10 ;;
+    6) "$TERMINAL" -e "$EDITOR" "$0" ;;
 esac
 
 # Loop through all attached batteries and format the info
 for battery in /sys/class/power_supply/BAT?*; do
-	# If non-first battery, print a space separator.
-	[ -n "${capacity+x}" ] && printf " "
-	# Sets up the status and capacity
-	case "$(cat "$battery/status")" in
-		"Full") status="⚡" ;;
-		"Discharging") status="🔋" ;;
-		"Charging") status="🔌" ;;
-		"Not charging") status="🛑" ;;
-		"Unknown") status="♻️" ;;
-	esac
-	capacity=$(cat "$battery/capacity")
-	# Will make a warn variable if discharging and low
-	[ "$status" = "🔋" ] && [ "$capacity" -le 25 ] && warn="❗"
-	# Prints the info
-	printf "%s%s%d%%" "$status" "$warn" "$capacity"; unset warn
+    # If non-first battery, print a space separator.
+    [ -n "${capacity+x}" ] && printf " "
+    # Sets up the status and capacity
+    case "$(cat "$battery/status")" in
+        "Full") status="⚡" ;;
+        "Discharging") status="🔋" ;;
+        "Charging") status="🔌" ;;
+        "Not charging") status="🛑" ;;
+        "Unknown") status="♻️" ;;
+    esac
+    capacity=$(cat "$battery/capacity")
+    # Will make a warn variable if discharging and low
+    [ "$status" = "🔋" ] && [ "$capacity" -le 25 ] && warn="❗"
+    # Prints the info
+    printf "%s%s%d%%" "$status" "$warn" "$capacity"
+    unset warn
 done && exit 0

--- a/.local/bin/statusbar/sb-clock
+++ b/.local/bin/statusbar/sb-clock
@@ -3,27 +3,27 @@
 clock=$(date '+%I')
 
 case "$clock" in
-	"00") icon="🕛" ;;
-	"01") icon="🕐" ;;
-	"02") icon="🕑" ;;
-	"03") icon="🕒" ;;
-	"04") icon="🕓" ;;
-	"05") icon="🕔" ;;
-	"06") icon="🕕" ;;
-	"07") icon="🕖" ;;
-	"08") icon="🕗" ;;
-	"09") icon="🕘" ;;
-	"10") icon="🕙" ;;
-	"11") icon="🕚" ;;
-	"12") icon="🕛" ;;
+    "00") icon="🕛" ;;
+    "01") icon="🕐" ;;
+    "02") icon="🕑" ;;
+    "03") icon="🕒" ;;
+    "04") icon="🕓" ;;
+    "05") icon="🕔" ;;
+    "06") icon="🕕" ;;
+    "07") icon="🕖" ;;
+    "08") icon="🕗" ;;
+    "09") icon="🕘" ;;
+    "10") icon="🕙" ;;
+    "11") icon="🕚" ;;
+    "12") icon="🕛" ;;
 esac
 
 case $BLOCK_BUTTON in
-	1) notify-send "This Month" "$(cal --color=always | sed "s/..7m/<b><span color=\"red\">/;s/..27m/<\/span><\/b>/")" && notify-send "Appointments" "$(calcurse -d3)" ;;
-	2) setsid -f "$TERMINAL" -e calcurse ;;
-	3) notify-send "📅 Time/date module" "\- Left click to show upcoming appointments for the next three days via \`calcurse -d3\` and show the month via \`cal\`
+    1) notify-send "This Month" "$(cal --color=always | sed "s/..7m/<b><span color=\"red\">/;s/..27m/<\/span><\/b>/")" && notify-send "Appointments" "$(calcurse -d3)" ;;
+    2) setsid -f "$TERMINAL" -e calcurse ;;
+    3) notify-send "📅 Time/date module" "\- Left click to show upcoming appointments for the next three days via \`calcurse -d3\` and show the month via \`cal\`
 - Middle click opens calcurse if installed" ;;
-	6) "$TERMINAL" -e "$EDITOR" "$0" ;;
+    6) "$TERMINAL" -e "$EDITOR" "$0" ;;
 esac
 
 date "+%Y %b %d (%a) $icon%I:%M%p"

--- a/.local/bin/statusbar/sb-cpu
+++ b/.local/bin/statusbar/sb-cpu
@@ -1,12 +1,12 @@
 #!/bin/sh
 
 case $BLOCK_BUTTON in
-	1) notify-send "🖥 CPU hogs" "$(ps axch -o cmd:15,%cpu --sort=-%cpu | head)\\n(100% per core)" ;;
-	2) setsid -f "$TERMINAL" -e htop ;;
-	3) notify-send "🖥 CPU module " "\- Shows CPU temperature.
+    1) notify-send "🖥 CPU hogs" "$(ps axch -o cmd:15,%cpu --sort=-%cpu | head)\\n(100% per core)" ;;
+    2) setsid -f "$TERMINAL" -e htop ;;
+    3) notify-send "🖥 CPU module " "\- Shows CPU temperature.
 - Click to show intensive processes.
 - Middle click to open htop." ;;
-	6) "$TERMINAL" -e "$EDITOR" "$0" ;;
+    6) "$TERMINAL" -e "$EDITOR" "$0" ;;
 esac
 
 sensors | awk '/Core 0/ {print "🌡" $3}'

--- a/.local/bin/statusbar/sb-cpubars
+++ b/.local/bin/statusbar/sb-cpubars
@@ -9,10 +9,10 @@
 cache=/tmp/cpubarscache
 
 case $BLOCK_BUTTON in
-	2) setsid -f "$TERMINAL" -e htop ;;
-	3) notify-send "🪨 CPU load module" "Each bar represents
-one CPU core";;
-	6) "$TERMINAL" -e "$EDITOR" "$0" ;;
+    2) setsid -f "$TERMINAL" -e htop ;;
+    3) notify-send "🪨 CPU load module" "Each bar represents
+one CPU core" ;;
+    6) "$TERMINAL" -e "$EDITOR" "$0" ;;
 esac
 
 # id total idle
@@ -21,24 +21,25 @@ stats=$(awk '/cpu[0-9]+/ {printf "%d %d %d\n", substr($1,4), ($2 + $3 + $4 + $5)
 old=$(cat "$cache")
 printf "🪨"
 echo "$stats" | while read -r row; do
-	id=${row%% *}
-	rest=${row#* }
-	total=${rest%% *}
-	idle=${rest##* }
+    id=${row%% *}
+    rest=${row#* }
+    total=${rest%% *}
+    idle=${rest##* }
 
-	case "$(echo "$old" | awk '{if ($1 == id)
+    case "$(echo "$old" | awk '{if ($1 == id)
 		printf "%d\n", (1 - (idle - $3)  / (total - $2))*100 /12.5}' \
-		id="$id" total="$total" idle="$idle")" in
+        id="$id" total="$total" idle="$idle")" in
 
-		"0") printf "▁";;
-		"1") printf "▂";;
-		"2") printf "▃";;
-		"3") printf "▄";;
-		"4") printf "▅";;
-		"5") printf "▆";;
-		"6") printf "▇";;
-		"7") printf "█";;
-		"8") printf "█";;
-	esac
-done; printf "\\n"
+        "0") printf "▁" ;;
+        "1") printf "▂" ;;
+        "2") printf "▃" ;;
+        "3") printf "▄" ;;
+        "4") printf "▅" ;;
+        "5") printf "▆" ;;
+        "6") printf "▇" ;;
+        "7") printf "█" ;;
+        "8") printf "█" ;;
+    esac
+done
+printf '\n'
 echo "$stats" > "$cache"

--- a/.local/bin/statusbar/sb-disk
+++ b/.local/bin/statusbar/sb-disk
@@ -8,16 +8,16 @@ location=${1:-/}
 [ -d "$location" ] || exit
 
 case $BLOCK_BUTTON in
-	1) notify-send "💽 Disk space" "$(df -h --output=target,used,size)" ;;
-	3) notify-send "💽 Disk module" "\- Shows used hard drive space.
+    1) notify-send "💽 Disk space" "$(df -h --output=target,used,size)" ;;
+    3) notify-send "💽 Disk module" "\- Shows used hard drive space.
 - Click to show all disk info." ;;
-	6) "$TERMINAL" -e "$EDITOR" "$0" ;;
+    6) "$TERMINAL" -e "$EDITOR" "$0" ;;
 esac
 
 case "$location" in
-	"/home"* ) icon="🏠" ;;
-	"/mnt"* ) icon="💾" ;;
-	*) icon="🖥";;
+    "/home"*) icon="🏠" ;;
+    "/mnt"*) icon="💾" ;;
+    *) icon="🖥" ;;
 esac
 
 printf "%s: %s\n" "$icon" "$(df -h "$location" | awk ' /[0-9]/ {print $3 "/" $2}')"

--- a/.local/bin/statusbar/sb-forecast
+++ b/.local/bin/statusbar/sb-forecast
@@ -7,29 +7,31 @@
 # You could set up a shell alias to view the full file in a pager in the
 # terminal if desired. This function will only be run once a day when needed.
 weatherreport="${XDG_DATA_HOME:-$HOME/.local/share}/weatherreport"
-getforecast() { curl -sf "wttr.in/$LOCATION" > "$weatherreport" || exit 1 ;}
+getforecast() { curl -sf "wttr.in/$LOCATION" > "$weatherreport" || exit 1; }
 
 # Some very particular and terse stream manipulation. We get the maximum
 # precipitation chance and the daily high and low from the downloaded file and
 # display them with coresponding emojis.
-showweather() { printf "%s" "$(sed '16q;d' "$weatherreport" |
-	grep -wo "[0-9]*%" | sort -rn | sed "s/^/☔/g;1q" | tr -d '\n')"
-sed '13q;d' "$weatherreport" | grep -o "m\\([-+]\\)*[0-9]\\+" | sed 's/+//g' | sort -n -t 'm' -k 2n | sed -e 1b -e '$!d' | tr '\n|m' ' ' | awk '{print " 🥶" $1 "°","🌞" $2 "°"}' ;}
+showweather() {
+    printf "%s" "$(sed '16q;d' "$weatherreport" \
+        | grep -wo "[0-9]*%" | sort -rn | sed "s/^/☔/g;1q" | tr -d '\n')"
+    sed '13q;d' "$weatherreport" | grep -o 'm\([-+]\)*[0-9]\+' | sed 's/+//g' | sort -n -t 'm' -k 2n | sed -e 1b -e '$!d' | tr '\n|m' ' ' | awk '{print " 🥶" $1 "°","🌞" $2 "°"}'
+}
 
 case $BLOCK_BUTTON in
-	1) setsid -f "$TERMINAL" -e less -Srf "$weatherreport" ;;
-	2) getforecast && showweather ;;
-	3) notify-send "🌈 Weather module" "\- Left click for full forecast.
+    1) setsid -f "$TERMINAL" -e less -Srf "$weatherreport" ;;
+    2) getforecast && showweather ;;
+    3) notify-send "🌈 Weather module" "\- Left click for full forecast.
 - Middle click to update forecast.
 ☔: Chance of rain/snow
 🥶: Daily low
 🌞: Daily high" ;;
-	6) "$TERMINAL" -e "$EDITOR" "$0" ;;
+    6) "$TERMINAL" -e "$EDITOR" "$0" ;;
 esac
 
 # The test if our forcecast is updated to the day. If it isn't download a new
 # weather report from wttr.in with the above function.
-[ "$(stat -c %y "$weatherreport" 2>/dev/null | cut -d' ' -f1)" = "$(date '+%Y-%m-%d')" ] ||
-	getforecast
+[ "$(stat -c %y "$weatherreport" 2> /dev/null | cut -d' ' -f1)" = "$(date '+%Y-%m-%d')" ] \
+    || getforecast
 
 showweather

--- a/.local/bin/statusbar/sb-help-icon
+++ b/.local/bin/statusbar/sb-help-icon
@@ -3,15 +3,16 @@
 # The clickable help menu. Middle click to restart wm.
 
 # If dwm is running, use dwm's readme and restart.
-pidof dwm >/dev/null &&
-	READMEFILE=/usr/local/share/dwm/larbs.mom
-	restartwm() { pkill -HUP dwm ;} ||
-		restartwm() { i3 restart ;}
+pidof dwm > /dev/null \
+    && READMEFILE=/usr/local/share/dwm/larbs.mom
+restartwm() { pkill -HUP dwm; } \
+    || restartwm() { i3 restart; }
 
 case $BLOCK_BUTTON in
-	1) groff -mom "${READMEFILE:-${XDG_DATA_HOME:-$HOME/.local/share}/larbs/readme.mom}" -Tpdf | zathura - ;;
-	2) restartwm ;;
-	3) notify-send "❓ Help module" "\- Left click to open LARBS guide.
+    1) groff -mom "${READMEFILE:-${XDG_DATA_HOME:-$HOME/.local/share}/larbs/readme.mom}" -Tpdf | zathura - ;;
+    2) restartwm ;;
+    3) notify-send "❓ Help module" "\- Left click to open LARBS guide.
 - Middle click to refresh window manager." ;;
-	6) "$TERMINAL" -e "$EDITOR" "$0" ;;
-esac; echo "❓"
+    6) "$TERMINAL" -e "$EDITOR" "$0" ;;
+esac
+echo "❓"

--- a/.local/bin/statusbar/sb-internet
+++ b/.local/bin/statusbar/sb-internet
@@ -5,20 +5,23 @@
 # Show 🔒 if a vpn connection is active
 
 case $BLOCK_BUTTON in
-	1) "$TERMINAL" -e nmtui; pkill -RTMIN+4 dwmblocks ;;
-	3) notify-send "🌐 Internet module" "\- Click to connect
+    1)
+        "$TERMINAL" -e nmtui
+        pkill -RTMIN+4 dwmblocks
+        ;;
+    3) notify-send "🌐 Internet module" "\- Click to connect
 📡: no wifi connection
 📶: wifi connection with quality
 ❎: no ethernet
 🌐: ethernet working
 🔒: vpn is active
 " ;;
-	6) "$TERMINAL" -e "$EDITOR" "$0" ;;
+    6) "$TERMINAL" -e "$EDITOR" "$0" ;;
 esac
 
-case "$(cat /sys/class/net/w*/operstate 2>/dev/null)" in
-	down) wifiicon="📡 " ;;
-	up) wifiicon="$(awk '/^\s*w/ { print "📶", int($3 * 100 / 70) "% " }' /proc/net/wireless)" ;;
+case "$(cat /sys/class/net/w*/operstate 2> /dev/null)" in
+    down) wifiicon="📡 " ;;
+    up) wifiicon="$(awk '/^\s*w/ { print "📶", int($3 * 100 / 70) "% " }' /proc/net/wireless)" ;;
 esac
 
-printf "%s%s%s\n" "$wifiicon" "$(sed "s/down/❎/;s/up/🌐/" /sys/class/net/e*/operstate 2>/dev/null)" "$(sed "s/.*/🔒/" /sys/class/net/tun*/operstate 2>/dev/null)"
+printf "%s%s%s\n" "$wifiicon" "$(sed "s/down/❎/;s/up/🌐/" /sys/class/net/e*/operstate 2> /dev/null)" "$(sed "s/.*/🔒/" /sys/class/net/tun*/operstate 2> /dev/null)"

--- a/.local/bin/statusbar/sb-iplocate
+++ b/.local/bin/statusbar/sb-iplocate
@@ -6,5 +6,5 @@
 # https://www.maketecheasier.com/ip-address-geolocation-lookups-linux/
 
 ifinstalled "geoip" || exit
-addr="$(curl ifconfig.me 2>/dev/null)" || exit
+addr="$(curl ifconfig.me 2> /dev/null)" || exit
 grep "flag: " "${XDG_DATA_HOME:-$HOME/.local/share}/larbs/emoji" | grep "$(geoiplookup "$addr" | sed 's/.*, //')" | sed "s/flag: //;s/;.*//"

--- a/.local/bin/statusbar/sb-kbselect
+++ b/.local/bin/statusbar/sb-kbselect
@@ -4,13 +4,15 @@
 kb="$(setxkbmap -query | grep -oP 'layout:\s*\K\w+')" || exit 1
 
 case $BLOCK_BUTTON in
-	1) kb_choice="$(awk '/! layout/{flag=1; next} /! variant/{flag=0} flag {print $2, "- " $1}' /usr/share/X11/xkb/rules/base.lst | dmenu -l 15)"
-	kb="$(echo "$kb_choice" | awk '{print $3}')"
-	setxkbmap "$kb"
-	pkill -RTMIN+30 "${STATUSBAR:-dwmblocks}";;
-	3) notify-send "⌨  Keyboard/language module" "$(printf "%s" "\- Current layout: $(setxkbmap -query | grep -oP 'layout:\s*\K\w+')")
-- Left click to change keyboard.";;
-	6) "$TERMINAL" -e "$EDITOR" "$0" ;;
+    1)
+        kb_choice="$(awk '/! layout/{flag=1; next} /! variant/{flag=0} flag {print $2, "- " $1}' /usr/share/X11/xkb/rules/base.lst | dmenu -l 15)"
+        kb="$(echo "$kb_choice" | awk '{print $3}')"
+        setxkbmap "$kb"
+        pkill -RTMIN+30 "${STATUSBAR:-dwmblocks}"
+        ;;
+    3) notify-send "⌨  Keyboard/language module" "$(printf "%s" "\- Current layout: $(setxkbmap -query | grep -oP 'layout:\s*\K\w+')")
+- Left click to change keyboard." ;;
+    6) "$TERMINAL" -e "$EDITOR" "$0" ;;
 esac
 
 echo "$kb"

--- a/.local/bin/statusbar/sb-mailbox
+++ b/.local/bin/statusbar/sb-mailbox
@@ -4,17 +4,17 @@
 # When clicked, brings up `neomutt`.
 
 case $BLOCK_BUTTON in
-	1) setsid -f "$TERMINAL" -e neomutt ;;
-	2) setsid -f mw sync >/dev/null ;;
-	3) notify-send "📬 Mail module" "\- Shows unread mail
+    1) setsid -f "$TERMINAL" -e neomutt ;;
+    2) setsid -f mw sync > /dev/null ;;
+    3) notify-send "📬 Mail module" "\- Shows unread mail
 - Shows 🔃 if syncing mail
 - Left click opens neomutt
 - Middle click syncs mail" ;;
-	6) "$TERMINAL" -e "$EDITOR" "$0" ;;
+    6) "$TERMINAL" -e "$EDITOR" "$0" ;;
 esac
 
-unread="$(find "${XDG_DATA_HOME:-$HOME/.local/share}"/mail/*/[Ii][Nn][Bb][Oo][Xx]/new/* -type f | wc -l 2>/dev/null)"
+unread="$(find "${XDG_DATA_HOME:-$HOME/.local/share}"/mail/*/[Ii][Nn][Bb][Oo][Xx]/new/* -type f | wc -l 2> /dev/null)"
 
-pidof mbsync >/dev/null 2>&1 && icon="🔃"
+pidof mbsync > /dev/null 2>&1 && icon="🔃"
 
 [ "$unread" = "0" ] && [ "$icon" = "" ] || echo "📬$unread$icon"

--- a/.local/bin/statusbar/sb-memory
+++ b/.local/bin/statusbar/sb-memory
@@ -1,12 +1,12 @@
 #!/bin/sh
 
 case $BLOCK_BUTTON in
-	1) notify-send "🧠 Memory hogs" "$(ps axch -o cmd:15,%mem --sort=-%mem | head)" ;;
-	2) setsid -f "$TERMINAL" -e htop ;;
-	3) notify-send "🧠 Memory module" "\- Shows Memory Used/Total.
+    1) notify-send "🧠 Memory hogs" "$(ps axch -o cmd:15,%mem --sort=-%mem | head)" ;;
+    2) setsid -f "$TERMINAL" -e htop ;;
+    3) notify-send "🧠 Memory module" "\- Shows Memory Used/Total.
 - Click to show memory hogs.
 - Middle click to open htop." ;;
-	6) "$TERMINAL" -e "$EDITOR" "$0" ;;
+    6) "$TERMINAL" -e "$EDITOR" "$0" ;;
 esac
 
 free --mebi | sed -n '2{p;q}' | awk '{printf ("🧠%2.2fGiB/%2.2fGiB\n", ( $3 / 1024), ($2 / 1024))}'

--- a/.local/bin/statusbar/sb-moonphase
+++ b/.local/bin/statusbar/sb-moonphase
@@ -4,27 +4,27 @@
 
 moonfile="${XDG_DATA_HOME:-$HOME/.local/share}/moonphase"
 
-[ "$(stat -c %y "$moonfile" 2>/dev/null | cut -d' ' -f1)" = "$(date '+%Y-%m-%d')" ] ||
-	{ curl -sf "wttr.in/?format=%m" > "$moonfile" || exit 1 ;}
+[ "$(stat -c %y "$moonfile" 2> /dev/null | cut -d' ' -f1)" = "$(date '+%Y-%m-%d')" ] \
+    || { curl -sf "wttr.in/?format=%m" > "$moonfile" || exit 1; }
 
 icon="$(cat "$moonfile")"
 
 case "$icon" in
-	🌑) name="New" ;;
-	🌒) name="Waxing Crescent" ;;
-	🌓) name="First Quarter" ;;
-	🌔) name="Waxing Gibbous" ;;
-	🌕) name="Full" ;;
-	🌖) name="Waning Gibbous" ;;
-	🌗) name="Last Quarter" ;;
-	🌘) name="Waning Crescent" ;;
-	*) exit 1 ;;
+    🌑) name="New" ;;
+    🌒) name="Waxing Crescent" ;;
+    🌓) name="First Quarter" ;;
+    🌔) name="Waxing Gibbous" ;;
+    🌕) name="Full" ;;
+    🌖) name="Waning Gibbous" ;;
+    🌗) name="Last Quarter" ;;
+    🌘) name="Waning Crescent" ;;
+    *) exit 1 ;;
 esac
 
 echo "${icon-?}"
 
 case $BLOCK_BUTTON in
-	3) notify-send "🌜 Moon phase module" "Displays current moon phase.
+    3) notify-send "🌜 Moon phase module" "Displays current moon phase.
 - 🌑: New
 - 🌒: Waxing Crescent
 - 🌓: First Quarter
@@ -33,5 +33,5 @@ case $BLOCK_BUTTON in
 - 🌖: Waning Gibbous
 - 🌗: Last Quarter
 - 🌘: Waning Crescent" ;;
-	6) "$TERMINAL" -e "$EDITOR" "$0" ;;
+    6) "$TERMINAL" -e "$EDITOR" "$0" ;;
 esac

--- a/.local/bin/statusbar/sb-mpdup
+++ b/.local/bin/statusbar/sb-mpdup
@@ -3,6 +3,6 @@
 # This loop will update the mpd statusbar module whenever a command changes the
 # music player's status. mpd must be running on X's start for this to work.
 
-while : ; do
-	mpc idle >/dev/null && kill -45 "$(pidof "${STATUSBAR:-dwmblocks}")" || break
+while :; do
+    mpc idle > /dev/null && kill -45 "$(pidof "${STATUSBAR:-dwmblocks}")" || break
 done

--- a/.local/bin/statusbar/sb-music
+++ b/.local/bin/statusbar/sb-music
@@ -1,19 +1,28 @@
 #!/bin/sh
 
-filter() { mpc | sed "/^volume:/d;s/\\&/&amp;/g;s/\\[paused\\].*/⏸/g;/\\[playing\\].*/d" | paste -sd ' ' -;}
+filter() { mpc | sed '/^volume:/d;s/\&/&amp;/g;s/\[paused\].*/⏸/g;/\[playing\].*/d' | paste -sd ' ' -; }
 
-pidof -x sb-mpdup >/dev/null 2>&1 || sb-mpdup >/dev/null 2>&1 &
+pidof -x sb-mpdup > /dev/null 2>&1 || sb-mpdup > /dev/null 2>&1 &
 
 case $BLOCK_BUTTON in
-	1) mpc status | filter ; setsid -f "$TERMINAL" -e ncmpcpp ;;  # right click, pause/unpause
-	2) mpc toggle | filter ;;  # right click, pause/unpause
-	3) mpc status | filter ; notify-send "🎵 Music module" "\- Shows mpd song playing.
+    1)
+        mpc status | filter
+        setsid -f "$TERMINAL" -e ncmpcpp
+        ;;                    # right click, pause/unpause
+    2) mpc toggle | filter ;; # right click, pause/unpause
+    3)
+        mpc status | filter
+        notify-send "🎵 Music module" "\- Shows mpd song playing.
 - ⏸ when paused.
 - Left click opens ncmpcpp.
 - Middle click pauses.
-- Scroll changes track.";;  # right click, pause/unpause
-	4) mpc prev   | filter ;;  # scroll up, previous
-	5) mpc next   | filter ;;  # scroll down, next
-	6) mpc status | filter ; "$TERMINAL" -e "$EDITOR" "$0" ;;
-	*) mpc status | filter ;;
+- Scroll changes track."
+        ;;                  # right click, pause/unpause
+    4) mpc prev | filter ;; # scroll up, previous
+    5) mpc next | filter ;; # scroll down, next
+    6)
+        mpc status | filter
+        "$TERMINAL" -e "$EDITOR" "$0"
+        ;;
+    *) mpc status | filter ;;
 esac

--- a/.local/bin/statusbar/sb-nettraf
+++ b/.local/bin/statusbar/sb-nettraf
@@ -5,25 +5,25 @@
 # second, gives network traffic per second.
 
 case $BLOCK_BUTTON in
-	1) setsid -f "$TERMINAL" -e bmon ;;
-	3) notify-send "🌐 Network traffic module" "🔻: Traffic received
+    1) setsid -f "$TERMINAL" -e bmon ;;
+    3) notify-send "🌐 Network traffic module" "🔻: Traffic received
 🔺: Traffic transmitted" ;;
-	6) "$TERMINAL" -e "$EDITOR" "$0" ;;
+    6) "$TERMINAL" -e "$EDITOR" "$0" ;;
 esac
 
 update() {
     sum=0
     for arg; do
         read -r i < "$arg"
-        sum=$(( sum + i ))
+        sum=$((sum + i))
     done
     cache=${XDG_CACHE_HOME:-$HOME/.cache}/${1##*/}
     [ -f "$cache" ] && read -r old < "$cache" || old=0
     printf %d\\n "$sum" > "$cache"
-    printf %d\\n $(( sum - old ))
+    printf %d\\n $((sum - old))
 }
 
 rx=$(update /sys/class/net/[ew]*/statistics/rx_bytes)
 tx=$(update /sys/class/net/[ew]*/statistics/tx_bytes)
 
-printf "🔻%4sB 🔺%4sB\\n" $(numfmt --to=iec $rx) $(numfmt --to=iec $tx)
+printf '🔻%4sB 🔺%4sB\n' $(numfmt --to=iec $rx) $(numfmt --to=iec $tx)

--- a/.local/bin/statusbar/sb-news
+++ b/.local/bin/statusbar/sb-news
@@ -4,14 +4,14 @@
 # When clicked, brings up `newsboat`.
 
 case $BLOCK_BUTTON in
-        1) setsid "$TERMINAL" -e newsboat ;;
-	2) setsid -f newsup >/dev/null exit ;;
-        3) notify-send "📰 News module" "\- Shows unread news items
+    1) setsid "$TERMINAL" -e newsboat ;;
+    2) setsid -f newsup exit > /dev/null ;;
+    3) notify-send "📰 News module" "\- Shows unread news items
 - Shows 🔃 if updating with \`newsup\`
 - Left click opens newsboat
 - Middle click syncs RSS feeds
 <b>Note:</b> Only one instance of newsboat (including updates) may be running at a time." ;;
-	6) "$TERMINAL" -e "$EDITOR" "$0" ;;
+    6) "$TERMINAL" -e "$EDITOR" "$0" ;;
 esac
 
- cat /tmp/newsupdate 2>/dev/null || echo "$(newsboat -x print-unread | awk '{ if($1>0) print "📰" $1}')$(cat "${XDG_CONFIG_HOME:-$HOME/.config}"/newsboat/.update 2>/dev/null)"
+cat /tmp/newsupdate 2> /dev/null || echo "$(newsboat -x print-unread | awk '{ if($1>0) print "📰" $1}')$(cat "${XDG_CONFIG_HOME:-$HOME/.config}"/newsboat/.update 2> /dev/null)"

--- a/.local/bin/statusbar/sb-pacpackages
+++ b/.local/bin/statusbar/sb-pacpackages
@@ -18,12 +18,12 @@
 # Exec = /usr/bin/pkill -RTMIN+8 dwmblocks # Or i3blocks if using i3.
 
 case $BLOCK_BUTTON in
-	1) setsid -f "$TERMINAL" -e sb-popupgrade ;;
-	2) notify-send "$(/usr/bin/pacman -Qu)" ;;
-	3) notify-send "🎁 Upgrade module" "📦: number of upgradable packages
+    1) setsid -f "$TERMINAL" -e sb-popupgrade ;;
+    2) notify-send "$(/usr/bin/pacman -Qu)" ;;
+    3) notify-send "🎁 Upgrade module" "📦: number of upgradable packages
 - Left click to upgrade packages
 - Middle click to show upgradable packages" ;;
-	6) "$TERMINAL" -e "$EDITOR" "$0" ;;
+    6) "$TERMINAL" -e "$EDITOR" "$0" ;;
 esac
 
 pacman -Qu | grep -Fcv "[ignored]" | sed "s/^/📦/;s/^📦0$//g"

--- a/.local/bin/statusbar/sb-popupgrade
+++ b/.local/bin/statusbar/sb-popupgrade
@@ -1,9 +1,9 @@
 #!/bin/sh
 
-printf "Beginning upgrade.\\n"
+printf 'Beginning upgrade.\n'
 
 yay -Syu
 pkill -RTMIN+8 "${STATUSBAR:-dwmblocks}"
 
-printf "\\nUpgrade complete.\\nPress <Enter> to exit window.\\n\\n"
+printf '\nUpgrade complete.\nPress <Enter> to exit window.\n\n'
 read -r _

--- a/.local/bin/statusbar/sb-price
+++ b/.local/bin/statusbar/sb-price
@@ -6,33 +6,37 @@
 # When the name of the currency is multi-word, put it in quotes.
 
 [ -z "$3" ] && exit 1
-interval="@14d"	# History contained in chart preceded by '@' (7d = 7 days)
+interval="@14d" # History contained in chart preceded by '@' (7d = 7 days)
 dir="${XDG_DATA_HOME:-$HOME/.local/share}/crypto-prices"
 pricefile="$dir/$1"
 chartfile="$dir/$1-chart"
 
-updateprice() { ping -q -c 1 example.org >/dev/null 2>&1 &&
-	curl -s "rate.sx/1$1" > "$pricefile" &&
-	curl -s "rate.sx/$1$interval" > "$chartfile" ;}
+updateprice() { ping -q -c 1 example.org > /dev/null 2>&1 \
+    && curl -s "rate.sx/1$1" > "$pricefile" \
+    && curl -s "rate.sx/$1$interval" > "$chartfile"; }
 
 [ -d "$dir" ] || mkdir -p "$dir"
 
-[ "$(stat -c %x "$pricefile" 2>/dev/null | cut -d' ' -f1)" != "$(date '+%Y-%m-%d')" ] &&
-	updateprice "$1"
+[ "$(stat -c %x "$pricefile" 2> /dev/null | cut -d' ' -f1)" != "$(date '+%Y-%m-%d')" ] \
+    && updateprice "$1"
 
 case $BLOCK_BUTTON in
-	1) setsid "$TERMINAL" -e less -Srf "$chartfile" ;;
-	2) notify-send -u low "$3 Updating..." "Updating $2 price..."
-		updateprice "$1" && notify-send "$3 Update complete." "$2 price is now
-\$$(cat "$pricefile")" ;;
-	3) uptime="$(date -d "$(stat -c %x "$pricefile")" '+%D at %T' | sed "s|$(date '+%D')|Today|")"
-		notify-send "$3 $2 module" "\- <b>Exact price: \$$(cat "$pricefile")</b>
+    1) setsid "$TERMINAL" -e less -Srf "$chartfile" ;;
+    2)
+        notify-send -u low "$3 Updating..." "Updating $2 price..."
+        updateprice "$1" && notify-send "$3 Update complete." "$2 price is now
+\$$(cat "$pricefile")"
+        ;;
+    3)
+        uptime="$(date -d "$(stat -c %x "$pricefile")" '+%D at %T' | sed "s|$(date '+%D')|Today|")"
+        notify-send "$3 $2 module" "\- <b>Exact price: \$$(cat "$pricefile")</b>
 - Left click for chart of changes.
 - Middle click to update.
 - Shows 🔃 if updating prices.
 - <b>Last updated:
-	$uptime</b>" ;;
-	6) "$TERMINAL" -e "$EDITOR" "$0" ;;
+	$uptime</b>"
+        ;;
+    6) "$TERMINAL" -e "$EDITOR" "$0" ;;
 esac
 
 printf "$3$%0.2f" "$(cat "$pricefile")"

--- a/.local/bin/statusbar/sb-tasks
+++ b/.local/bin/statusbar/sb-tasks
@@ -10,11 +10,11 @@ num=$(tsp -l | awk -v numr=0 -v numq=0 '{if (/running/)numr++; if (/queued/)numq
 
 # Handle mouse clicks
 case $BLOCK_BUTTON in
-	1) setsid -f "$TERMINAL" -e tsp -l ;;
-	3) notify-send "Tasks module" "🤖: number of running/queued background tasks
+    1) setsid -f "$TERMINAL" -e tsp -l ;;
+    3) notify-send "Tasks module" "🤖: number of running/queued background tasks
 - Left click opens tsp" ;; # Right click
-	2) $EDITOR "$0" ;; # Middle click
+    2) $EDITOR "$0" ;;     # Middle click
 esac
 
-[ "$num" != "0(0)" ] &&
-	echo "🤖$num"
+[ "$num" != "0(0)" ] \
+    && echo "🤖$num"

--- a/.local/bin/statusbar/sb-torrent
+++ b/.local/bin/statusbar/sb-torrent
@@ -1,19 +1,19 @@
 #!/bin/sh
 
-transmission-remote -l | grep % |
-	sed " # The letters are for sorting and will not appear.
+transmission-remote -l | grep % \
+    | sed " # The letters are for sorting and will not appear.
 	s/.*Stopped.*/A 🛑/;
 	s/.*Seeding.*/Z 🌱/;
 	s/.*100%.*/N ✅/;
 	s/.*Idle.*/B 🕰️/;
 	s/.*Uploading.*/L ⬆️/;
-	s/.*%.*/M ⬇️/" |
-		sort -h | uniq -c | awk '{print $3 $1}' | paste -sd ' ' -
+	s/.*%.*/M ⬇️/" \
+    | sort -h | uniq -c | awk '{print $3 $1}' | paste -sd ' ' -
 
 case $BLOCK_BUTTON in
-	1) setsid -f "$TERMINAL" -e tremc ;;
-	2) td-toggle ;;
-	3) notify-send "🌱 Torrent module" "\- Left click to open tremc.
+    1) setsid -f "$TERMINAL" -e tremc ;;
+    2) td-toggle ;;
+    3) notify-send "🌱 Torrent module" "\- Left click to open tremc.
 - Middle click to toggle transmission.
 - Shift click to edit script.
 Module shows number of torrents:
@@ -23,5 +23,5 @@ Module shows number of torrents:
 🔽: downloading
 ✅: done
 🌱: done and seeding" ;;
-	6) "$TERMINAL" -e "$EDITOR" "$0" ;;
+    6) "$TERMINAL" -e "$EDITOR" "$0" ;;
 esac

--- a/.local/bin/statusbar/sb-volume
+++ b/.local/bin/statusbar/sb-volume
@@ -3,14 +3,14 @@
 # Prints the current volume or 🔇 if muted.
 
 case $BLOCK_BUTTON in
-	1) setsid -f "$TERMINAL" -e pulsemixer ;;
-	2) pamixer -t ;;
-	4) pamixer --allow-boost -i 1 ;;
-	5) pamixer --allow-boost -d 1 ;;
-	3) notify-send "📢 Volume module" "\- Shows volume 🔊, 🔇 if muted.
+    1) setsid -f "$TERMINAL" -e pulsemixer ;;
+    2) pamixer -t ;;
+    4) pamixer --allow-boost -i 1 ;;
+    5) pamixer --allow-boost -d 1 ;;
+    3) notify-send "📢 Volume module" "\- Shows volume 🔊, 🔇 if muted.
 - Middle click to mute.
 - Scroll to change." ;;
-	6) "$TERMINAL" -e "$EDITOR" "$0" ;;
+    6) "$TERMINAL" -e "$EDITOR" "$0" ;;
 esac
 
 [ $(pamixer --get-mute) = true ] && echo 🔇 && exit
@@ -18,11 +18,11 @@ esac
 vol="$(pamixer --get-volume)"
 
 if [ "$vol" -gt "70" ]; then
-	icon="🔊"
+    icon="🔊"
 elif [ "$vol" -lt "30" ]; then
-	icon="🔈"
+    icon="🔈"
 else
-	icon="🔉"
+    icon="🔉"
 fi
 
 echo "$icon$vol%"

--- a/.local/bin/sysact
+++ b/.local/bin/sysact
@@ -4,8 +4,11 @@
 
 # For non-systemd init systems.
 case "$(readlink -f /sbin/init)" in
-	*runit*) hib="sudo -A zzz" ;;
-	*openrc*) reb="sudo -A openrc-shutdown -r"; shut="sudo -A openrc-shutdown -p" ;;
+    *runit*) hib="sudo -A zzz" ;;
+    *openrc*)
+        reb="sudo -A openrc-shutdown -r"
+        shut="sudo -A openrc-shutdown -p"
+        ;;
 esac
 
 cmds="\
@@ -18,4 +21,4 @@ cmds="\
 
 choice="$(echo "$cmds" | cut -d'	' -f 1 | dmenu)" || exit 1
 
-`echo "$cmds" | grep "^$choice	" | cut -d '	' -f2-`
+$(echo "$cmds" | grep "^$choice	" | cut -d '	' -f2-)

--- a/.local/bin/tag
+++ b/.local/bin/tag
@@ -11,20 +11,20 @@ Options:
 	-d: year of publication
 	-g: genre
 	-c: comment
-You will be prompted for title, artist, album and track if not given." && exit 1 ;}
+You will be prompted for title, artist, album and track if not given." && exit 1; }
 
 while getopts "a:t:A:n:N:d:g:c:f:" o; do case "${o}" in
-	a) artist="${OPTARG}" ;;
-	t) title="${OPTARG}" ;;
-	A) album="${OPTARG}" ;;
-	n) track="${OPTARG}" ;;
-	N) total="${OPTARG}" ;;
-	d) date="${OPTARG}" ;;
-	g) genre="${OPTARG}" ;;
-	c) comment="${OPTARG}" ;;
-	f) file="${OPTARG}" ;;
-	*) printf "Invalid option: -%s\\n" "$OPTARG" && err ;;
-esac done
+    a) artist="${OPTARG}" ;;
+    t) title="${OPTARG}" ;;
+    A) album="${OPTARG}" ;;
+    n) track="${OPTARG}" ;;
+    N) total="${OPTARG}" ;;
+    d) date="${OPTARG}" ;;
+    g) genre="${OPTARG}" ;;
+    c) comment="${OPTARG}" ;;
+    f) file="${OPTARG}" ;;
+    *) printf 'Invalid option: -%s\n' "$OPTARG" && err ;;
+esac; done
 
 shift $((OPTIND - 1))
 
@@ -38,7 +38,7 @@ file="$1"
 [ -z "$track" ] && echo "Enter a track number." && read -r track
 
 case "$file" in
-	*.ogg) echo "Title=$title
+    *.ogg) echo "Title=$title
 Artist=$artist
 Album=$album
 Track=$track
@@ -46,7 +46,7 @@ Total=$total
 Date=$date
 Genre=$genre
 Comment=$comment" | vorbiscomment -w "$file" ;;
-	*.opus) echo "Title=$title
+    *.opus) echo "Title=$title
 Artist=$artist
 Album=$album
 Track=$track
@@ -54,8 +54,8 @@ Total=$total
 Date=$date
 Genre=$genre
 Comment=$comment" | opustags -i -S "$file" ;;
-	*.mp3) eyeD3 -Q --remove-all -a "$artist" -A "$album" -t "$title" -n "$track" -N "$total" -Y "$date" "$file" ;;
-	*.flac) echo "TITLE=$title
+    *.mp3) eyeD3 -Q --remove-all -a "$artist" -A "$album" -t "$title" -n "$track" -N "$total" -Y "$date" "$file" ;;
+    *.flac) echo "TITLE=$title
 ARTIST=$artist
 ALBUM=$album
 TRACKNUMBER=$track
@@ -63,5 +63,5 @@ TOTALTRACKS=$total
 DATE=$date
 GENRE=$genre
 DESCRIPTION=$comment" | metaflac --remove-all-tags --import-tags-from=- "$file" ;;
-	*) echo "File type not implemented yet." ;;
+    *) echo "File type not implemented yet." ;;
 esac

--- a/.local/bin/td-toggle
+++ b/.local/bin/td-toggle
@@ -2,11 +2,10 @@
 
 # If transmission-daemon is running, will ask to kill, else will ask to start.
 
-if pidof transmission-daemon >/dev/null ;
-then
-	[ "$(printf "No\\nYes" | dmenu -i -p "Turn off transmission-daemon?")" = "Yes" ] && killall transmission-da && notify-send "transmission-daemon disabled."
+if pidof transmission-daemon > /dev/null; then
+    [ "$(printf 'No\nYes' | dmenu -i -p "Turn off transmission-daemon?")" = "Yes" ] && killall transmission-da && notify-send "transmission-daemon disabled."
 else
-	ifinstalled transmission-cli || exit
-	[ "$(printf "No\\nYes" | dmenu -i -p "Turn on transmission daemon?")" = "Yes" ] && transmission-daemon && notify-send "tranmission-daemon enabled."
+    ifinstalled transmission-cli || exit
+    [ "$(printf 'No\nYes' | dmenu -i -p "Turn on transmission daemon?")" = "Yes" ] && transmission-daemon && notify-send "tranmission-daemon enabled."
 fi
 sleep 3 && pkill -RTMIN+7 "${STATUSBAR:-dwmblocks}"

--- a/.local/bin/texclear
+++ b/.local/bin/texclear
@@ -4,13 +4,12 @@
 # I have vim run this file whenever I exit a .tex file.
 
 case "$1" in
-	*.tex)
-	file=$(readlink -f "$1")
-	dir=$(dirname "$file")
-	base="${file%.*}"
-	find "$dir"  -maxdepth 1 -type f -regextype gnu-awk -regex "^$base\\.(4tc|xref|tmp|pyc|pyg|pyo|fls|vrb|fdb_latexmk|bak|swp|aux|log|synctex\\(busy\\)|lof|lot|maf|idx|mtc|mtc0|nav|out|snm|toc|bcf|run\\.xml|synctex\\.gz|blg|bbl)" -delete
-	rm -rdf "$dir/_minted-$(basename -- $base)"
-	;;
-	*) printf "Give .tex file as argument.\\n" ;;
+    *.tex)
+        file=$(readlink -f "$1")
+        dir=$(dirname "$file")
+        base="${file%.*}"
+        find "$dir" -maxdepth 1 -type f -regextype gnu-awk -regex "^$base\\.(4tc|xref|tmp|pyc|pyg|pyo|fls|vrb|fdb_latexmk|bak|swp|aux|log|synctex\\(busy\\)|lof|lot|maf|idx|mtc|mtc0|nav|out|snm|toc|bcf|run\\.xml|synctex\\.gz|blg|bbl)" -delete
+        rm -rdf "$dir/_minted-$(basename -- $base)"
+        ;;
+    *) printf 'Give .tex file as argument.\n' ;;
 esac
-

--- a/.local/bin/torwrap
+++ b/.local/bin/torwrap
@@ -2,6 +2,7 @@
 
 ifinstalled tremc-git transmission-cli || exit
 
-! pidof transmission-daemon >/dev/null && transmission-daemon && notify-send "Starting torrent daemon..."
+! pidof transmission-daemon > /dev/null && transmission-daemon && notify-send "Starting torrent daemon..."
 
-$TERMINAL -e tremc; pkill -RTMIN+7 "${STATUSBAR:-dwmblocks}"
+$TERMINAL -e tremc
+pkill -RTMIN+7 "${STATUSBAR:-dwmblocks}"

--- a/.local/bin/transadd
+++ b/.local/bin/transadd
@@ -4,6 +4,6 @@
 
 # transmission-daemon sometimes fails to take remote requests in its first moments, hence the sleep.
 
-pidof transmission-daemon >/dev/null || (transmission-daemon && notify-send "Starting transmission daemon..." && sleep 3 && pkill -RTMIN+7 "${STATUSBAR:-dwmblocks}")
+pidof transmission-daemon > /dev/null || (transmission-daemon && notify-send "Starting transmission daemon..." && sleep 3 && pkill -RTMIN+7 "${STATUSBAR:-dwmblocks}")
 
 transmission-remote -a "$@" && notify-send "🔽 Torrent added."


### PR DESCRIPTION
- Format all shell scripts using [shfmt]
  (https://github.com/mvdan/sh).

Options used:

* `-bn`: binary ops like && and | may start a line
* `-sr`: redirect operators will be followed by a space
* `-ci`: indent switch cases
* `-i 4`: indent 4 spaces
* `-s`: simplify the code
* `-p`: parse for posix compliance

- Add Github action to lint changes to scripts and enforce formatting
  going forward

Signed-off-by: Vladislav Doster <mvdoster@gmail.com>